### PR TITLE
feat: add sampler close method

### DIFF
--- a/cmd/kafka-sampler/kafka/sarama/handler.go
+++ b/cmd/kafka-sampler/kafka/sarama/handler.go
@@ -43,6 +43,12 @@ func (h *SamplerHandler) Setup(sess sarama.ConsumerGroupSession) error {
 // Cleanup is run at the end of a session, once all ConsumeClaim goroutines have exited
 func (h *SamplerHandler) Cleanup(sarama.ConsumerGroupSession) error {
 	// Clean samplers
+	for topic, sampler := range h.samplers {
+		if err := sampler.Close(); err != nil {
+			h.logger.Error("error closing sampler for topic %s: %w", topic, err)
+		}
+	}
+
 	h.samplers = map[string]defs.Sampler{}
 
 	return nil

--- a/sampler/defs/sampler.go
+++ b/sampler/defs/sampler.go
@@ -16,4 +16,7 @@ type Sampler interface {
 	// SampleProto samples a data sampled encoded as a proto message. The protoSample parameter has to be the same
 	// type as the proto message provided as schema when creating the sampler.
 	SampleProto(ctx context.Context, protoSample proto.Message) (bool, error)
+	// Close closes all Sampler connections with the Control and Data planes. Once closed,
+	// the Sampler can't be reused and none of its methods can be called.
+	Close() error
 }

--- a/sampler/global/global_test.go
+++ b/sampler/global/global_test.go
@@ -24,6 +24,9 @@ func (p *mockSampler) SampleNative(ctx context.Context, nativeSample any) (bool,
 func (p *mockSampler) SampleProto(ctx context.Context, protoSample proto.Message) (bool, error) {
 	return true, nil
 }
+func (p *mockSampler) Close() error {
+	return nil
+}
 
 type mockProvider struct {
 }

--- a/sampler/global/provider.go
+++ b/sampler/global/provider.go
@@ -120,3 +120,12 @@ func (pw *samplerPlaceholder) SampleProto(ctx context.Context, protoSample proto
 
 	return false, nil
 }
+
+func (pw *samplerPlaceholder) Close() error {
+	delegate := pw.delegate.Load()
+	if delegate != nil {
+		return delegate.(defs.Sampler).Close()
+	}
+
+	return nil
+}

--- a/sampler/internal/sample/exporter/exporter.go
+++ b/sampler/internal/sample/exporter/exporter.go
@@ -8,4 +8,5 @@ import (
 
 type Exporter interface {
 	Export(context.Context, []sample.ResourceSamples) error
+	Close(context.Context) error
 }

--- a/sampler/internal/sampler/options.go
+++ b/sampler/internal/sampler/options.go
@@ -7,6 +7,8 @@ import (
 	"github.com/neblic/platform/sampler/internal/sample/exporter"
 )
 
+const closeTimeout = time.Duration(2) * time.Second
+
 type AuthBearerOptions struct {
 	Token string
 }

--- a/sampler/internal/sampler/sampler.go
+++ b/sampler/internal/sampler/sampler.go
@@ -240,3 +240,15 @@ func (p *Sampler) sample(ctx context.Context, evalSample *rule.EvalSample) (bool
 
 	return false, nil
 }
+
+func (p *Sampler) Close() error {
+	if err := p.controlPlaneClient.Close(closeTimeout); err != nil {
+		return fmt.Errorf("error closing control plane client: %w", err)
+	}
+
+	if err := p.exporter.Close(context.Background()); err != nil {
+		return fmt.Errorf("error closing samples exporter: %w", err)
+	}
+
+	return nil
+}

--- a/sampler/test/sampler_behavior_test.go
+++ b/sampler/test/sampler_behavior_test.go
@@ -86,6 +86,8 @@ var _ = Describe("Sampler", func() {
 				sampled, err := p.SampleJSON(context.Background(), `{"id": 1}`)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sampled).To(BeFalse())
+
+				Expect(p.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -168,6 +170,8 @@ var _ = Describe("Sampler", func() {
 						return receiver.TotalItems.Load() == 1
 					},
 					time.Second, time.Millisecond)
+
+				Expect(p.Close()).ToNot(HaveOccurred())
 			})
 
 			It("is a native sample it should export the sample", func() {
@@ -196,6 +200,8 @@ var _ = Describe("Sampler", func() {
 						return receiver.TotalItems.Load() == 1
 					},
 					time.Second, time.Millisecond)
+
+				Expect(p.Close()).ToNot(HaveOccurred())
 			})
 
 			It("is a proto sample it should export the sample", func() {
@@ -224,6 +230,8 @@ var _ = Describe("Sampler", func() {
 						return receiver.TotalItems.Load() == 1
 					},
 					time.Second, time.Millisecond)
+
+				Expect(p.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -319,6 +327,7 @@ var _ = Describe("Sampler", func() {
 					},
 					time.Second, time.Millisecond)
 
+				Expect(p.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -359,11 +368,13 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				_, err = provider.Sampler("sampler1", defs.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				<-registered
 				<-statsReceived
+
+				Expect(p.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
## Describe your changes

* Add Close() method to sampler
* Call Sampler Close() method when the topic that the Sampler is associated with stops being monitored 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
