### PR TITLE
fix(controlplane): do not store any instance information to avoid partially initialized instances

### DIFF
--- a/controlplane/server/internal/defs/sampler.go
+++ b/controlplane/server/internal/defs/sampler.go
@@ -20,11 +20,11 @@ func NewSamplerIdentifier(resource string, name string) SamplerIdentifier {
 
 type SamplerInstance struct {
 	UID     control.SamplerUID
-	Sampler *Sampler                     `json:"-"`
-	Stats   control.SamplerSamplingStats `json:"-"`
-	Conn    SamplerConn                  `json:"-"`
-	Dirty   bool                         `json:"-"`
-	Status  Status                       `json:"-"`
+	Sampler *Sampler
+	Stats   control.SamplerSamplingStats
+	Conn    SamplerConn
+	Dirty   bool
+	Status  Status
 }
 
 func NewSamplerInstance(uid control.SamplerUID, sampler *Sampler) *SamplerInstance {
@@ -42,7 +42,7 @@ type Sampler struct {
 	Resource  string
 	Name      string
 	Config    control.SamplerConfig
-	Instances map[control.SamplerUID]*SamplerInstance
+	Instances map[control.SamplerUID]*SamplerInstance `json:"-"`
 
 	// EventRules is used to evaluate event rules. It is computed from the config events
 	EventRules map[control.SamplerEventUID]*rule.Rule `json:"-"`


### PR DESCRIPTION
## Describe your changes

* never load any sampler instance information from disk

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
