### PR TITLE
Fix controlplane instances initialization when loading from disk

### DIFF
--- a/controlplane/server/internal/registry/registry_sampler.go
+++ b/controlplane/server/internal/registry/registry_sampler.go
@@ -45,7 +45,7 @@ func NewSamplerRegistry(logger logging.Logger, notifyDirty chan struct{}, storag
 		}
 	}
 
-	// Intialize the dynamic rule builder
+	// Initialize the dynamic rule builder
 	ruleBuilder, err := rule.NewBuilder(rule.NewDynamicSchema())
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize the dynamic rule builder")
@@ -55,7 +55,7 @@ func NewSamplerRegistry(logger logging.Logger, notifyDirty chan struct{}, storag
 	samplers := map[defs.SamplerIdentifier]*defs.Sampler{}
 	storageInstance.Range(func(key defs.SamplerIdentifier, sampler *defs.Sampler) {
 
-		// Intialize event rules
+		// Initialize event rules
 		eventRules := map[control.SamplerEventUID]*rule.Rule{}
 		for eventUID, event := range sampler.Config.Events {
 			rule, err := ruleBuilder.Build(event.Rule.Expression)
@@ -70,7 +70,7 @@ func NewSamplerRegistry(logger logging.Logger, notifyDirty chan struct{}, storag
 		// Initialize instances (not persisted)
 		sampler.Instances = map[control.SamplerUID]*defs.SamplerInstance{}
 
-		// Intialize sampler
+		// Initialize sampler
 		sampler.EventRules = eventRules
 
 		samplers[key] = sampler

--- a/controlplane/server/internal/registry/registry_sampler.go
+++ b/controlplane/server/internal/registry/registry_sampler.go
@@ -67,10 +67,8 @@ func NewSamplerRegistry(logger logging.Logger, notifyDirty chan struct{}, storag
 			eventRules[eventUID] = rule
 		}
 
-		// Initialize instances
-		for _, instance := range sampler.Instances {
-			instance.Status = defs.UnknownStatus
-		}
+		// Initialize instances (not persisted)
+		sampler.Instances = map[control.SamplerUID]*defs.SamplerInstance{}
 
 		// Intialize sampler
 		sampler.EventRules = eventRules


### PR DESCRIPTION
## Describe your changes
When reading from disk the persisted configuration, instances are not correctly initialized. The result was a panic trying to access an instance during the reconciliation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
