### PR TITLE
fix(sampler): make sampler schema definitons public

### DIFF
--- a/cmd/kafka-sampler/kafka/sarama/handler.go
+++ b/cmd/kafka-sampler/kafka/sarama/handler.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/hashicorp/go-multierror"
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/logging"
 	"github.com/neblic/platform/sampler/defs"
 	"github.com/neblic/platform/sampler/global"
@@ -31,7 +30,7 @@ func (h *SamplerHandler) Setup(sess sarama.ConsumerGroupSession) error {
 	// Initialize one sampler for each topic
 	samplerProvider := global.SamplerProvider()
 	for topic := range sess.Claims() {
-		sampler, err := samplerProvider.Sampler(topic, rule.NewDynamicSchema())
+		sampler, err := samplerProvider.Sampler(topic, defs.NewDynamicSchema())
 		if err != nil {
 			errors = multierror.Append(errors, fmt.Errorf("cannot initialize sampler for topic %s: %w", topic, err))
 		}

--- a/controlplane/server/internal/registry/registry_sampler.go
+++ b/controlplane/server/internal/registry/registry_sampler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/neblic/platform/controlplane/server/internal/registry/storage"
 	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/logging"
+	samplerDefs "github.com/neblic/platform/sampler/defs"
 )
 
 var (
@@ -46,7 +47,7 @@ func NewSamplerRegistry(logger logging.Logger, notifyDirty chan struct{}, storag
 	}
 
 	// Initialize the dynamic rule builder
-	ruleBuilder, err := rule.NewBuilder(rule.NewDynamicSchema())
+	ruleBuilder, err := rule.NewBuilder(samplerDefs.NewDynamicSchema())
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize the dynamic rule builder")
 	}

--- a/controlplane/server/otelcolext/processor.go
+++ b/controlplane/server/otelcolext/processor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/neblic/platform/internal/pkg/data"
 	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/logging"
+	"github.com/neblic/platform/sampler/defs"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -71,7 +72,7 @@ func newLogsProcessor(cfg *Config, zapLogger *zap.Logger, nextConsumer consumer.
 		return nil, component.ErrNilNextConsumer
 	}
 
-	builder, err := rule.NewBuilder(rule.NewDynamicSchema())
+	builder, err := rule.NewBuilder(defs.NewDynamicSchema())
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize the rule builder: %w", err)
 	}

--- a/internal/pkg/rule/builder.go
+++ b/internal/pkg/rule/builder.go
@@ -4,23 +4,24 @@ import (
 	"fmt"
 
 	"github.com/google/cel-go/cel"
+	"github.com/neblic/platform/sampler/defs"
 )
 
 type Builder struct {
-	schema Schema
+	schema defs.Schema
 	env    *cel.Env
 }
 
 const sampleKey = "sample"
 
-func NewBuilder(schema Schema) (*Builder, error) {
+func NewBuilder(schema defs.Schema) (*Builder, error) {
 	var celEnvOpts []cel.EnvOption
 
 	// Add custom functions to the environemnt
 	celEnvOpts = append(celEnvOpts, CelFunctions...)
 
 	switch s := schema.(type) {
-	case ProtoSchema:
+	case defs.ProtoSchema:
 		typ := string(s.Proto.ProtoReflect().Descriptor().FullName())
 		celEnvOpts = append(celEnvOpts,
 			cel.Types(s.Proto),
@@ -28,7 +29,7 @@ func NewBuilder(schema Schema) (*Builder, error) {
 				cel.ObjectType(typ),
 			),
 		)
-	case DynamicSchema:
+	case defs.DynamicSchema:
 		celEnvOpts = append(celEnvOpts,
 			cel.Variable(sampleKey, cel.MapType(cel.StringType, cel.DynType)),
 		)

--- a/internal/pkg/rule/rule.go
+++ b/internal/pkg/rule/rule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/neblic/platform/internal/pkg/data"
+	"github.com/neblic/platform/sampler/defs"
 )
 
 type sampleCompatibility uint8
@@ -17,12 +18,12 @@ const (
 )
 
 type Rule struct {
-	schema     Schema
+	schema     defs.Schema
 	prg        cel.Program
 	sampleComp sampleCompatibility
 }
 
-func New(schema Schema, prg cel.Program) *Rule {
+func New(schema defs.Schema, prg cel.Program) *Rule {
 	r := &Rule{
 		schema: schema,
 		prg:    prg,
@@ -32,11 +33,11 @@ func New(schema Schema, prg cel.Program) *Rule {
 	return r
 }
 
-func (r *Rule) setCompatibility(schema Schema) {
+func (r *Rule) setCompatibility(schema defs.Schema) {
 	switch schema.(type) {
-	case DynamicSchema:
+	case defs.DynamicSchema:
 		r.sampleComp = jsonComp | nativeComp | protoComp
-	case ProtoSchema:
+	case defs.ProtoSchema:
 		r.sampleComp = protoComp
 	}
 }

--- a/internal/pkg/rule/rule_test.go
+++ b/internal/pkg/rule/rule_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/neblic/platform/controlplane/protos"
 	"github.com/neblic/platform/internal/pkg/data"
+	"github.com/neblic/platform/sampler/defs"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
@@ -28,7 +29,7 @@ func TestEvalJSON(t *testing.T) {
 		wantMatch: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			rb, err := NewBuilder(DynamicSchema{})
+			rb, err := NewBuilder(defs.DynamicSchema{})
 			require.NoError(t, err)
 
 			rule, err := rb.Build(tc.filter)
@@ -73,7 +74,7 @@ func TestEvalNative(t *testing.T) {
 		wantMatch: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			rb, err := NewBuilder(NewDynamicSchema())
+			rb, err := NewBuilder(defs.NewDynamicSchema())
 			require.NoError(t, err)
 
 			rule, err := rb.Build(tc.filter)
@@ -114,7 +115,7 @@ func TestEvalProto(t *testing.T) {
 		wantMatch: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			rb, err := NewBuilder(NewProtoSchema(&protos.SamplerToServer{}))
+			rb, err := NewBuilder(defs.NewProtoSchema(&protos.SamplerToServer{}))
 			require.NoError(t, err)
 
 			rule, err := rb.Build(tc.filter)

--- a/sampler/defs/provider.go
+++ b/sampler/defs/provider.go
@@ -1,7 +1,5 @@
 package defs
 
-import "github.com/neblic/platform/internal/pkg/rule"
-
 // Provider defines a sampler provider object capable of creating new samplers.
 type Provider interface {
 	// Sampler creates a new sampler with the specified schema. It currently supports Dynamic and Proto schemas.
@@ -11,5 +9,5 @@ type Provider interface {
 	// * A Proto schema requires the caller to provide a proto message (type proto.Message) to define the sampler schema.
 	// All sampled data is expected to be provided as proto messages with the sampler.SampleProto() method, and it should
 	// be the same type as the one provided when defining the sampler schema.
-	Sampler(name string, schema rule.Schema) (Sampler, error)
+	Sampler(name string, schema Schema) (Sampler, error)
 }

--- a/sampler/defs/schema.go
+++ b/sampler/defs/schema.go
@@ -1,4 +1,4 @@
-package rule
+package defs
 
 import "google.golang.org/protobuf/proto"
 

--- a/sampler/global/global_test.go
+++ b/sampler/global/global_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/sampler/defs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +12,7 @@ import (
 
 type mockSampler struct {
 	name   string
-	schema rule.Schema
+	schema defs.Schema
 }
 
 func (p *mockSampler) SampleJSON(ctx context.Context, jsonSample string) (bool, error) {
@@ -35,13 +34,13 @@ func (p *mockSampler) Close() error {
 type mockProvider struct {
 }
 
-func (p *mockProvider) Sampler(name string, schema rule.Schema) (defs.Sampler, error) {
+func (p *mockProvider) Sampler(name string, schema defs.Schema) (defs.Sampler, error) {
 	return &mockSampler{name, schema}, nil
 }
 
 func TestSetSamplerProvider(t *testing.T) {
 	// without setting a provider, samplers should be placeholders
-	pp, err := SamplerProvider().Sampler("placeHolderSampler", rule.NewDynamicSchema())
+	pp, err := SamplerProvider().Sampler("placeHolderSampler", defs.NewDynamicSchema())
 	require.NoError(t, err)
 	assert.IsType(t, &samplerPlaceholder{}, pp)
 
@@ -58,7 +57,7 @@ func TestSetSamplerProvider(t *testing.T) {
 	assert.Equal(t, true, match)
 
 	// new samplers should be mocks since it is what the mock provider returns
-	pp2, err := SamplerProvider().Sampler("mockSampler", rule.NewDynamicSchema())
+	pp2, err := SamplerProvider().Sampler("mockSampler", defs.NewDynamicSchema())
 	require.NoError(t, err)
 	assert.IsType(t, &mockSampler{}, pp2)
 }

--- a/sampler/global/provider.go
+++ b/sampler/global/provider.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/sampler/defs"
 )
 
@@ -53,7 +52,7 @@ func (p *samplerProviderPlaceholder) setDelegate(pp defs.Provider) error {
 	return aggErr
 }
 
-func (p *samplerProviderPlaceholder) Sampler(name string, schema rule.Schema) (defs.Sampler, error) {
+func (p *samplerProviderPlaceholder) Sampler(name string, schema defs.Schema) (defs.Sampler, error) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -79,7 +78,7 @@ var _ defs.Sampler = &samplerPlaceholder{}
 
 type samplerPlaceholder struct {
 	name   string
-	schema rule.Schema
+	schema defs.Schema
 
 	delegate atomic.Value
 }

--- a/sampler/instrumentation/google.golang.org/grpc/interceptor.go
+++ b/sampler/instrumentation/google.golang.org/grpc/interceptor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	oldProto "github.com/golang/protobuf/proto"
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/sampler/defs"
 	"github.com/neblic/platform/sampler/global"
 	"google.golang.org/grpc"
@@ -30,7 +29,7 @@ func getProtoSampler(samplers map[string]defs.Sampler, key string, schema proto.
 	if sampler, ok = samplers[key]; !ok {
 		sampler, _ = global.SamplerProvider().Sampler(
 			key,
-			rule.NewProtoSchema(schema),
+			defs.NewProtoSchema(schema),
 		)
 		samplers[key] = sampler
 	}

--- a/sampler/internal/sampler/options.go
+++ b/sampler/internal/sampler/options.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/neblic/platform/controlplane/control"
-	"github.com/neblic/platform/internal/pkg/rule"
+	"github.com/neblic/platform/sampler/defs"
 	"github.com/neblic/platform/sampler/internal/sample/exporter"
 )
 
@@ -22,7 +22,7 @@ type AuthOptions struct {
 type Settings struct {
 	Name     string
 	Resource string
-	Schema   rule.Schema
+	Schema   defs.Schema
 
 	ControlPlaneAddr string
 	EnableTLS        bool

--- a/sampler/provider.go
+++ b/sampler/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/logging"
 	"github.com/neblic/platform/sampler/defs"
 	"github.com/neblic/platform/sampler/internal/sample/exporter"
@@ -75,7 +74,7 @@ func NewProvider(ctx context.Context, settings Settings, opts ...Option) (defs.P
 }
 
 // Sampler creates a new sampler. See the interface comments for more details.
-func (p *Provider) Sampler(name string, schema rule.Schema) (defs.Sampler, error) {
+func (p *Provider) Sampler(name string, schema defs.Schema) (defs.Sampler, error) {
 	samplerOpts := &sampler.Settings{
 		Name:     name,
 		Resource: p.settings.ResourceName,

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -1,7 +1,6 @@
 package sampler
 
 import (
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/sampler/defs"
 	"github.com/neblic/platform/sampler/global"
 )
@@ -9,6 +8,6 @@ import (
 // Sampler creates a new sampler using the global provider.
 // Since it uses the global sampler provider, it is necessary to set one for the samplers to work.
 // See global.SamplerProvider() and global.SetSamplerProvider(...) methods for more details.
-func Sampler(name string, schema rule.Schema) (defs.Sampler, error) {
+func Sampler(name string, schema defs.Schema) (defs.Sampler, error) {
 	return global.SamplerProvider().Sampler(name, schema)
 }

--- a/sampler/test/docs/sampler_test.go
+++ b/sampler/test/docs/sampler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	// --8<-- [start:SamplerInitImport]
-	"github.com/neblic/platform/internal/pkg/rule"
+
 	"github.com/neblic/platform/sampler"
 	"github.com/neblic/platform/sampler/defs"
 	// --8<-- [end:SamplerInitImport]
@@ -17,7 +17,7 @@ var someSampler defs.Sampler
 func initSampler() defs.Sampler {
 	// initialize the schema that the sampled `Data Samples` will
 	// a `DynamicSchema` supports Json strings and Go structs
-	schema := rule.NewDynamicSchema()
+	schema := defs.NewDynamicSchema()
 
 	// equivalent to calling `global.SamplerProvider().Sampler()`
 	someSampler, _ := sampler.Sampler("sampler-name", schema)

--- a/sampler/test/sampler_behavior_test.go
+++ b/sampler/test/sampler_behavior_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/neblic/platform/controlplane/protos"
 	"github.com/neblic/platform/controlplane/server/mock"
-	"github.com/neblic/platform/internal/pkg/rule"
 	"github.com/neblic/platform/logging"
 	"github.com/neblic/platform/sampler"
 	"github.com/neblic/platform/sampler/defs"
@@ -103,7 +102,7 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
@@ -152,7 +151,7 @@ var _ = Describe("Sampler", func() {
 		When("there is a matching rule but exporting raw samples is disabled", func() {
 			It("should not export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -226,7 +225,7 @@ var _ = Describe("Sampler", func() {
 		When("there is a matching rule and", func() {
 			It("is a JSON sample it should export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -255,7 +254,7 @@ var _ = Describe("Sampler", func() {
 
 			It("is a native sample it should export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -285,7 +284,7 @@ var _ = Describe("Sampler", func() {
 
 			It("is a proto sample it should export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.NewProtoSchema(&protos.SamplerToServer{}))
+				p, err := provider.Sampler("sampler1", defs.NewProtoSchema(&protos.SamplerToServer{}))
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -364,7 +363,7 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := providerLimitedOut.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := providerLimitedOut.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -437,7 +436,7 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := providerLimitedOut.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := providerLimitedOut.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -487,7 +486,7 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := providerLimitedIn.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := providerLimitedIn.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -539,7 +538,7 @@ var _ = Describe("Sampler", func() {
 				)
 				Expect(err).ToNot(HaveOccurred())
 				// create a sampler
-				p, err := providerSampledIn.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := providerSampledIn.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// wait until the server has configured the sampler
@@ -627,7 +626,7 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				<-registered
@@ -675,7 +674,7 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := provider.Sampler("sampler1", rule.DynamicSchema{})
+				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
 				<-configured


### PR DESCRIPTION
## Describe your changes

Sampler `Schema` type should be public so it can be used when initializing a `Sampler`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
