### PR TITLE
fix: do not segault if there is a nil value while processing a st digest

### DIFF
--- a/dataplane/digest/st.go
+++ b/dataplane/digest/st.go
@@ -128,6 +128,10 @@ func (s *St) updateValue(prevVal *protos.ValueSt, x interface{}) (*protos.ValueS
 		prevVal = &protos.ValueSt{}
 	}
 
+	if x == nil {
+		return prevVal, nil
+	}
+
 	v := reflect.ValueOf(x)
 	switch v.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,


### PR DESCRIPTION
## Describe your changes

If the value passed to the struct digest was nil, that would make the sampler to segfault.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
