### PR TITLE
fix(controlplane): only support raw sample type in events

### DIFF
--- a/cmd/neblictl/internal/controlplane/completers.go
+++ b/cmd/neblictl/internal/controlplane/completers.go
@@ -138,11 +138,7 @@ func (c *Completers) ListDigestsName(ctx context.Context, parameters interpoler.
 }
 
 func (c *Completers) ListSampleType(ctx context.Context, parameters interpoler.ParametersWithValue) []string {
-	sampleTypes := []string{}
-	for _, sampleType := range control.ValidSampleTypes {
-		sampleTypes = append(sampleTypes, sampleType.String())
-	}
-	return sampleTypes
+	return []string{control.RawSampleType.String()}
 }
 
 func (c *Completers) ListEventsName(ctx context.Context, parameters interpoler.ParametersWithValue) []string {

--- a/controlplane/control/event.go
+++ b/controlplane/control/event.go
@@ -133,10 +133,17 @@ func NewEventUpdateFromProto(eventUpdate *protos.ClientEventUpdate) EventUpdate 
 	}
 }
 func (eu *EventUpdate) IsValid() error {
+	// Validate event name
 	isValid := nameValidationRegex.MatchString(string(eu.Event.Name))
 	if !isValid {
 		return fmt.Errorf(nameValidationErrTemplate, "event", eu.Event.Name)
 	}
+
+	// Validate sample type when updating a rule
+	if eu.Op == EventUpsert && eu.Event.SampleType != RawSampleType {
+		return fmt.Errorf("invalid sample type %s", eu.Event.SampleType.String())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Describe your changes
Events are generic enough to be able to support any sample type (raw samples, struct digests and value digests), but only raw samples will be supported right now (that could change in the future) for the following reasons.
- struct digests: User does not know the schema of the message
- value digests: User does not know the schema of the message, value digests are produced in the collector using a different channel and events does not read from it at this time

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
