### PR TITLE
fix(neblictl): pull full config after configure command

### DIFF
--- a/cmd/neblictl/internal/controlplane/client.go
+++ b/cmd/neblictl/internal/controlplane/client.go
@@ -169,5 +169,10 @@ func (c *Client) setSamplerConfig(ctx context.Context, name, resource string, up
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	return c.internal.ConfigureSampler(ctx, resource, name, update)
+	err := c.internal.ConfigureSampler(ctx, resource, name, update)
+
+	// Update local cache
+	c.pullSamplerConfigs(ctx)
+
+	return err
 }


### PR DESCRIPTION
## Describe your changes
After creating a new sampler/event/digest, a manual list command has to be executed to be able to use it (the completer does not have the new state and does not give the option to use it). This PR fixes this issue by forcing a pull of the config after each configure command

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
