### PR TITLE
fix(controlplane): sampler deregister not working

### DIFF
--- a/controlplane/server/internal/protocol/sampler/sampler.go
+++ b/controlplane/server/internal/protocol/sampler/sampler.go
@@ -73,7 +73,9 @@ func (p *Sampler) streamStateChangeCb(state defs.Status, name, resource string, 
 
 		p.registeredOnce = true
 	case defs.UnregisteredStatus:
-		if err := p.samplerRegistry.Deregister(resource, name, uid); err != nil {
+		// Unregistered status could happen when a connection is closed. In that case, name and resource
+		// parameters are empty.
+		if err := p.samplerRegistry.Deregister(uid); err != nil {
 			return fmt.Errorf("error deregistering client, uid: %s: %w", uid, err)
 		}
 

--- a/controlplane/server/internal/registry/registry_sampler.go
+++ b/controlplane/server/internal/registry/registry_sampler.go
@@ -208,19 +208,22 @@ func (sr *SamplerRegistry) Register(resource string, name string, uid control.Sa
 	return err
 }
 
-func (sr *SamplerRegistry) Deregister(resource string, name string, uid control.SamplerUID) error {
+func (sr *SamplerRegistry) Deregister(uid control.SamplerUID) error {
 	sr.m.Lock()
 	defer sr.m.Unlock()
 
-	sampler, err := sr.getSampler(resource, name)
-	if err != nil {
-		return ErrUnknownSampler
+	// Find sampler instance
+	var found bool
+	var sampler *defs.Sampler
+	for _, sampler = range sr.samplers {
+		_, ok := sampler.GetInstance(uid)
+		if ok {
+			found = true
+			break
+		}
 	}
-
-	_, ok := sampler.Instances[uid]
-	if !ok {
-		sr.logger.Error("deregistering unknown sampler, nothing to do", "sampler_uid", uid)
-		return nil
+	if !found {
+		return ErrUnknownSamplerInstance
 	}
 
 	delete(sampler.Instances, uid)


### PR DESCRIPTION
## Describe your changes
Sampler deregister operation can be graceful (sampler sends a deregister operation) or unexpected (sampler dies). In the last scenario, resource and name cannot be recovered because there is no request and the data is not stored in the stream. As a result the current logic does not work as expected.

There are two ways to fix this issue:
- Unregister just using the sampler uid
- Store the resource and sampler in the stream, and recover that information during the deregister operation. In case of doing that, other changes could be made to avoid having to provide the resource and sampler in each request coming from the sampler.

For the sake of simplicity, the first approach was the one used

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have made the appropriate changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If it is a major user facing functionality, I have added behavioural tests
- [ ] If it is a critical part of the code or of significant complexity, I have added thorough testing
