### PR TITLE
fix(dataplane): sample config propagation during sampler registration

### DIFF
--- a/controlplane/server/internal/registry/registry_sampler.go
+++ b/controlplane/server/internal/registry/registry_sampler.go
@@ -205,6 +205,15 @@ func (sr *SamplerRegistry) Register(resource string, name string, uid control.Sa
 
 	err = sr.setSampler(resource, name, sampler)
 
+	// Send upsert event if necessary
+	if sr.eventsChan != nil {
+		sr.eventsChan <- ConfigUpdate{
+			Resource: resource,
+			Sampler:  name,
+			Config:   sampler.Config,
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
## Describe your changes
The first time a sampler gets registered (with no state stored), configuration does not get propagated to the cloud. The solution is to generate an event at registration time.

Fixes # (issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
