### PR TITLE
feat(controlplane): sampler automatically creates stream and digest

### DIFF
--- a/cmd/neblictl/internal/controlplane/views.go
+++ b/cmd/neblictl/internal/controlplane/views.go
@@ -109,12 +109,12 @@ func NewListSamplersConfigView() *ListSamplersConfigView {
 }
 
 func (lscv *ListSamplersConfigView) AddSampler(sampler *control.Sampler) {
-	limiterIn := "default"
+	limiterIn := "none"
 	if sampler.Config.LimiterIn != nil {
 		limiterIn = fmt.Sprintf("%d", sampler.Config.LimiterIn.Limit)
 	}
 
-	samplingIn := "default"
+	samplingIn := "none"
 	if sampler.Config.SamplingIn != nil {
 		switch sampler.Config.SamplingIn.SamplingType {
 		case control.DeterministicSamplingType:
@@ -127,7 +127,7 @@ func (lscv *ListSamplersConfigView) AddSampler(sampler *control.Sampler) {
 		}
 	}
 
-	limiterOut := "default"
+	limiterOut := "none"
 	if sampler.Config.LimiterOut != nil {
 		limiterOut = fmt.Sprintf("%d", sampler.Config.LimiterOut.Limit)
 	}

--- a/controlplane/control/sampler.go
+++ b/controlplane/control/sampler.go
@@ -302,7 +302,7 @@ func (pc *SamplerConfig) Merge(update SamplerConfigUpdate) {
 		pc.LimiterOut = nil
 	}
 	if update.LimiterOut != nil {
-		pc.LimiterIn = update.LimiterOut
+		pc.LimiterOut = update.LimiterOut
 	}
 
 	// Update Digests

--- a/controlplane/internal/stream/handler.go
+++ b/controlplane/internal/stream/handler.go
@@ -79,13 +79,15 @@ type SamplerHandler struct {
 	name            string
 	resource        string
 	recvServerReqCb func(*protos.ServerToSampler) (bool, *protos.SamplerToServer, error)
+	initialConfig   *protos.ClientSamplerConfigUpdate
 }
 
-func NewSamplerHandler(name, resource string, recvServerReqCb func(*protos.ServerToSampler) (bool, *protos.SamplerToServer, error)) Handler[*protos.ServerToSampler, *protos.SamplerToServer] {
+func NewSamplerHandler(name, resource string, recvServerReqCb func(*protos.ServerToSampler) (bool, *protos.SamplerToServer, error), initialConfig *protos.ClientSamplerConfigUpdate) Handler[*protos.ServerToSampler, *protos.SamplerToServer] {
 	return &SamplerHandler{
 		name:            name,
 		resource:        resource,
 		recvServerReqCb: recvServerReqCb,
+		initialConfig:   initialConfig,
 	}
 }
 
@@ -109,7 +111,9 @@ func (ch SamplerHandler) toServerMsg(uid string) *protos.SamplerToServer {
 func (ch SamplerHandler) regReqMsg(uid string) *protos.SamplerToServer {
 	toServerMsg := ch.toServerMsg(uid)
 	toServerMsg.Message = &protos.SamplerToServer_RegisterReq{
-		RegisterReq: &protos.SamplerRegisterReq{},
+		RegisterReq: &protos.SamplerRegisterReq{
+			SamplerConfigUpdate: ch.initialConfig,
+		},
 	}
 
 	return toServerMsg

--- a/controlplane/protos/controlplane.pb.go
+++ b/controlplane/protos/controlplane.pb.go
@@ -1772,7 +1772,8 @@ type SamplerRegisterReq struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Tags map[string]string `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	SamplerConfigUpdate *ClientSamplerConfigUpdate `protobuf:"bytes,1,opt,name=sampler_config_update,json=samplerConfigUpdate,proto3" json:"sampler_config_update,omitempty"`
+	Tags                map[string]string          `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
 func (x *SamplerRegisterReq) Reset() {
@@ -1805,6 +1806,13 @@ func (x *SamplerRegisterReq) ProtoReflect() protoreflect.Message {
 // Deprecated: Use SamplerRegisterReq.ProtoReflect.Descriptor instead.
 func (*SamplerRegisterReq) Descriptor() ([]byte, []int) {
 	return file_protos_controlplane_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *SamplerRegisterReq) GetSamplerConfigUpdate() *ClientSamplerConfigUpdate {
+	if x != nil {
+		return x.SamplerConfigUpdate
+	}
+	return nil
 }
 
 func (x *SamplerRegisterReq) GetTags() map[string]string {
@@ -3021,8 +3029,13 @@ var file_protos_controlplane_proto_rawDesc = []byte{
 	0x61, 0x6d, 0x70, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x73, 0x74, 0x61, 0x74, 0x73, 0x18, 0x02, 0x20,
 	0x01, 0x28, 0x0b, 0x32, 0x15, 0x2e, 0x53, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x72, 0x53, 0x61, 0x6d,
 	0x70, 0x6c, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x61, 0x74, 0x73, 0x52, 0x0d, 0x73, 0x61, 0x6d, 0x70,
-	0x6c, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x61, 0x74, 0x73, 0x22, 0x80, 0x01, 0x0a, 0x12, 0x53, 0x61,
+	0x6c, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x61, 0x74, 0x73, 0x22, 0xd0, 0x01, 0x0a, 0x12, 0x53, 0x61,
 	0x6d, 0x70, 0x6c, 0x65, 0x72, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x65, 0x72, 0x52, 0x65, 0x71,
+	0x12, 0x4e, 0x0a, 0x15, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x72, 0x5f, 0x63, 0x6f, 0x6e, 0x66,
+	0x69, 0x67, 0x5f, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x1a, 0x2e, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x72, 0x43,
+	0x6f, 0x6e, 0x66, 0x69, 0x67, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x52, 0x13, 0x73, 0x61, 0x6d,
+	0x70, 0x6c, 0x65, 0x72, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65,
 	0x12, 0x31, 0x0a, 0x04, 0x74, 0x61, 0x67, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1d,
 	0x2e, 0x53, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x72, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x65, 0x72,
 	0x52, 0x65, 0x71, 0x2e, 0x54, 0x61, 0x67, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x04, 0x74,
@@ -3271,40 +3284,41 @@ var file_protos_controlplane_proto_depIdxs = []int32{
 	33, // 35: ServerToClient.list_samplers_res:type_name -> ClientListSamplersRes
 	39, // 36: ServerToClient.sampler_conf_res:type_name -> ClientSamplerConfRes
 	16, // 37: SamplerStatsMsg.sampling_stats:type_name -> SamplerSamplingStats
-	42, // 38: SamplerRegisterReq.tags:type_name -> SamplerRegisterReq.TagsEntry
-	7,  // 39: SamplerRegisterRes.status:type_name -> Status
-	15, // 40: ServerSamplerConfReq.sampler_config:type_name -> SamplerConfig
-	7,  // 41: ServerSamplerConfRes.status:type_name -> Status
-	16, // 42: ClientSamplerStats.sampling_stats:type_name -> SamplerSamplingStats
-	28, // 43: ClientSamplerStatsMsg.sampler_stats:type_name -> ClientSamplerStats
-	43, // 44: ClientRegisterReq.tags:type_name -> ClientRegisterReq.TagsEntry
-	7,  // 45: ClientRegisterRes.status:type_name -> Status
-	7,  // 46: ClientListSamplersRes.status:type_name -> Status
-	18, // 47: ClientListSamplersRes.samplers:type_name -> Sampler
-	4,  // 48: ClientStreamUpdate.op:type_name -> ClientStreamUpdate.Op
-	12, // 49: ClientStreamUpdate.stream:type_name -> Stream
-	5,  // 50: ClientDigestUpdate.op:type_name -> ClientDigestUpdate.Op
-	13, // 51: ClientDigestUpdate.digest:type_name -> Digest
-	6,  // 52: ClientEventUpdate.op:type_name -> ClientEventUpdate.Op
-	14, // 53: ClientEventUpdate.event:type_name -> Event
-	44, // 54: ClientSamplerConfigUpdate.reset:type_name -> ClientSamplerConfigUpdate.Reset
-	34, // 55: ClientSamplerConfigUpdate.stream_updates:type_name -> ClientStreamUpdate
-	10, // 56: ClientSamplerConfigUpdate.limiter_in:type_name -> Limiter
-	9,  // 57: ClientSamplerConfigUpdate.sampling_in:type_name -> Sampling
-	10, // 58: ClientSamplerConfigUpdate.limiter_out:type_name -> Limiter
-	35, // 59: ClientSamplerConfigUpdate.digest_updates:type_name -> ClientDigestUpdate
-	36, // 60: ClientSamplerConfigUpdate.event_updates:type_name -> ClientEventUpdate
-	37, // 61: ClientSamplerConfReq.sampler_config_update:type_name -> ClientSamplerConfigUpdate
-	7,  // 62: ClientSamplerConfRes.status:type_name -> Status
-	19, // 63: ControlPlane.SamplerConn:input_type -> SamplerToServer
-	21, // 64: ControlPlane.ClientConn:input_type -> ClientToServer
-	20, // 65: ControlPlane.SamplerConn:output_type -> ServerToSampler
-	22, // 66: ControlPlane.ClientConn:output_type -> ServerToClient
-	65, // [65:67] is the sub-list for method output_type
-	63, // [63:65] is the sub-list for method input_type
-	63, // [63:63] is the sub-list for extension type_name
-	63, // [63:63] is the sub-list for extension extendee
-	0,  // [0:63] is the sub-list for field type_name
+	37, // 38: SamplerRegisterReq.sampler_config_update:type_name -> ClientSamplerConfigUpdate
+	42, // 39: SamplerRegisterReq.tags:type_name -> SamplerRegisterReq.TagsEntry
+	7,  // 40: SamplerRegisterRes.status:type_name -> Status
+	15, // 41: ServerSamplerConfReq.sampler_config:type_name -> SamplerConfig
+	7,  // 42: ServerSamplerConfRes.status:type_name -> Status
+	16, // 43: ClientSamplerStats.sampling_stats:type_name -> SamplerSamplingStats
+	28, // 44: ClientSamplerStatsMsg.sampler_stats:type_name -> ClientSamplerStats
+	43, // 45: ClientRegisterReq.tags:type_name -> ClientRegisterReq.TagsEntry
+	7,  // 46: ClientRegisterRes.status:type_name -> Status
+	7,  // 47: ClientListSamplersRes.status:type_name -> Status
+	18, // 48: ClientListSamplersRes.samplers:type_name -> Sampler
+	4,  // 49: ClientStreamUpdate.op:type_name -> ClientStreamUpdate.Op
+	12, // 50: ClientStreamUpdate.stream:type_name -> Stream
+	5,  // 51: ClientDigestUpdate.op:type_name -> ClientDigestUpdate.Op
+	13, // 52: ClientDigestUpdate.digest:type_name -> Digest
+	6,  // 53: ClientEventUpdate.op:type_name -> ClientEventUpdate.Op
+	14, // 54: ClientEventUpdate.event:type_name -> Event
+	44, // 55: ClientSamplerConfigUpdate.reset:type_name -> ClientSamplerConfigUpdate.Reset
+	34, // 56: ClientSamplerConfigUpdate.stream_updates:type_name -> ClientStreamUpdate
+	10, // 57: ClientSamplerConfigUpdate.limiter_in:type_name -> Limiter
+	9,  // 58: ClientSamplerConfigUpdate.sampling_in:type_name -> Sampling
+	10, // 59: ClientSamplerConfigUpdate.limiter_out:type_name -> Limiter
+	35, // 60: ClientSamplerConfigUpdate.digest_updates:type_name -> ClientDigestUpdate
+	36, // 61: ClientSamplerConfigUpdate.event_updates:type_name -> ClientEventUpdate
+	37, // 62: ClientSamplerConfReq.sampler_config_update:type_name -> ClientSamplerConfigUpdate
+	7,  // 63: ClientSamplerConfRes.status:type_name -> Status
+	19, // 64: ControlPlane.SamplerConn:input_type -> SamplerToServer
+	21, // 65: ControlPlane.ClientConn:input_type -> ClientToServer
+	20, // 66: ControlPlane.SamplerConn:output_type -> ServerToSampler
+	22, // 67: ControlPlane.ClientConn:output_type -> ServerToClient
+	66, // [66:68] is the sub-list for method output_type
+	64, // [64:66] is the sub-list for method input_type
+	64, // [64:64] is the sub-list for extension type_name
+	64, // [64:64] is the sub-list for extension extendee
+	0,  // [0:64] is the sub-list for field type_name
 }
 
 func init() { file_protos_controlplane_proto_init() }

--- a/controlplane/sampler/options.go
+++ b/controlplane/sampler/options.go
@@ -3,6 +3,7 @@ package sampler
 import (
 	"time"
 
+	"github.com/neblic/platform/controlplane/control"
 	"github.com/neblic/platform/controlplane/internal/stream"
 	"github.com/neblic/platform/logging"
 )
@@ -12,6 +13,8 @@ type options struct {
 
 	updateStatsPeriod time.Duration
 	logger            logging.Logger
+
+	initialConfig control.SamplerConfigUpdate
 }
 
 func newDefaultSamplerOptions() *options {
@@ -22,7 +25,8 @@ func newDefaultSamplerOptions() *options {
 			KeepAliveMaxPeriod: time.Second * time.Duration(10),
 			ServerReqsQueueLen: 10,
 		},
-		logger: logging.NewNopLogger(),
+		logger:        logging.NewNopLogger(),
+		initialConfig: control.NewSamplerConfigUpdate(),
 	}
 }
 
@@ -90,5 +94,11 @@ func WithAuthBearer(token string) Option {
 func WithLogger(l logging.Logger) Option {
 	return newFuncOption(func(po *options) {
 		po.logger = l
+	})
+}
+
+func WithInitialConfig(c control.SamplerConfigUpdate) Option {
+	return newFuncOption(func(po *options) {
+		po.initialConfig = c
 	})
 }

--- a/controlplane/sampler/sampler.go
+++ b/controlplane/sampler/sampler.go
@@ -42,7 +42,7 @@ func New(name, resource string, samplerOptions ...Option) *Sampler {
 	p.samplerStream = stream.New(
 		string(p.data.UID),
 		opts.streamOpts,
-		stream.NewSamplerHandler(p.data.Name, p.data.Resource, p.recvServerReqCb),
+		stream.NewSamplerHandler(p.data.Name, p.data.Resource, p.recvServerReqCb, opts.initialConfig.ToProto()),
 		p.logger,
 	)
 

--- a/controlplane/server/internal/protocol/stream/handler.go
+++ b/controlplane/server/internal/protocol/stream/handler.go
@@ -94,7 +94,7 @@ func (ClientHandler) fromServerMsg(uid string) *protos.ServerToClient {
 }
 
 type SamplerRecvFromServerReqFunc func(*protos.SamplerToServer) (bool, *protos.ServerToSampler, error)
-type SamplerStatusChangeFunc func(defs.Status, string, string, control.SamplerUID) error
+type SamplerStatusChangeFunc func(defs.Status, control.SamplerUID, *protos.SamplerToServer) error
 
 type SamplerHandler struct {
 	rectToServerReqCb SamplerRecvFromServerReqFunc
@@ -143,7 +143,7 @@ func (ph SamplerHandler) startRegistration(req *protos.SamplerToServer) (string,
 }
 
 func (ph SamplerHandler) finishRegistration(req *protos.SamplerToServer) error {
-	if err := ph.statusChangeCb(defs.RegisteredStatus, req.Name, req.Resouce, control.SamplerUID(req.GetSamplerUid())); err != nil {
+	if err := ph.statusChangeCb(defs.RegisteredStatus, control.SamplerUID(req.GetSamplerUid()), req); err != nil {
 		return err
 	}
 
@@ -151,7 +151,7 @@ func (ph SamplerHandler) finishRegistration(req *protos.SamplerToServer) error {
 }
 
 func (ph SamplerHandler) deregister(uid string) error {
-	return ph.statusChangeCb(defs.UnregisteredStatus, "", "", control.SamplerUID(uid))
+	return ph.statusChangeCb(defs.UnregisteredStatus, control.SamplerUID(uid), nil)
 }
 
 func (SamplerHandler) fromServerMsg(uid string) *protos.ServerToSampler {

--- a/protos/controlplane.proto
+++ b/protos/controlplane.proto
@@ -226,6 +226,7 @@ message SamplerStatsMsg { SamplerSamplingStats sampling_stats = 2; }
 // register
 
 message SamplerRegisterReq {
+  ClientSamplerConfigUpdate sampler_config_update = 1;
   map<string, string> tags = 3;
 }
 

--- a/sampler/internal/sampler/options.go
+++ b/sampler/internal/sampler/options.go
@@ -28,10 +28,9 @@ type Settings struct {
 	EnableTLS        bool
 	Auth             AuthOptions
 
-	LimiterIn  control.LimiterConfig
-	SamplingIn control.SamplingConfig
-	Exporter   exporter.Exporter
-	LimiterOut control.LimiterConfig
+	SamplingIn    control.SamplingConfig
+	InitialConfig control.SamplerConfigUpdate
+	Exporter      exporter.Exporter
 
 	UpdateStatsPeriod time.Duration
 

--- a/sampler/internal/sampler/sampler.go
+++ b/sampler/internal/sampler/sampler.go
@@ -55,6 +55,7 @@ func New(
 
 	var clientOpts []csampler.Option
 	clientOpts = append(clientOpts, csampler.WithLogger(logger))
+	clientOpts = append(clientOpts, csampler.WithInitialConfig(settings.InitialConfig))
 	if settings.EnableTLS {
 		clientOpts = append(clientOpts, csampler.WithTLS())
 	}
@@ -104,9 +105,9 @@ func New(
 		resourceName: settings.Resource,
 
 		streams:    make(map[control.SamplerStreamUID]streamConfig),
-		limiterIn:  rate.NewLimiter(rate.Limit(settings.LimiterIn.Limit), int(settings.LimiterIn.Limit)),
+		limiterIn:  rate.NewLimiter(rate.Limit(settings.InitialConfig.LimiterIn.Limit), int(settings.InitialConfig.LimiterIn.Limit)),
 		samplerIn:  samplerIn,
-		limiterOut: rate.NewLimiter(rate.Limit(settings.LimiterOut.Limit), int(settings.LimiterOut.Limit)),
+		limiterOut: rate.NewLimiter(rate.Limit(settings.InitialConfig.LimiterOut.Limit), int(settings.InitialConfig.LimiterOut.Limit)),
 
 		controlPlaneClient: controlPlaneClient,
 		digester:           digester,

--- a/sampler/options.go
+++ b/sampler/options.go
@@ -38,7 +38,6 @@ type options struct {
 	controlServerAuth authOption
 	dataServerAuth    authOption
 
-	samplingIn    control.SamplingConfig
 	initialConfig control.SamplerConfigUpdate
 
 	updateStatsPeriod time.Duration
@@ -85,7 +84,6 @@ func newDefaultOptions() *options {
 		controlServerTLSEnable: false,
 		dataServerTLSEnable:    false,
 
-		samplingIn:    control.SamplingConfig{},
 		initialConfig: initialConfig,
 
 		updateStatsPeriod: time.Second * time.Duration(5),
@@ -149,12 +147,23 @@ func WithInitialLimiterInLimit(l int32) Option {
 	})
 }
 
-// WithDeterministicSamplingIn defines a deterministic sampling strategy which will be applied when a sample is received and before processing it in any way
-// (e.g. before determining if a sample belongs to a stream which would require parsing it and evaluating the stream rules).
-// Sampling is performed after the input limiter has been applied.
+// WithDeterministicSamplingIn defines a deterministic sampling strategy which will be applied
+//
+// Deprecated: Use WithInitialDeterministicSamplingIn instead
 func WithDeterministicSamplingIn(samplingRate int32) Option {
+	return WithInitialDeterministicSamplingIn(samplingRate)
+}
+
+// WithInitialDeterministicSamplingIn defines a deterministic sampling strategy which will be applied
+// when a sample is received and before processing it in any way (e.g. before determining if a sample belongs
+// to a stream which would require parsing it and evaluating the stream rules).
+// Sampling is performed after the input limiter has been applied.
+// This configuration is only used the first time a sampler is registered with a server, posterior executions
+// will use the configuration stored in the server and the provided configuration will be
+// ignored.
+func WithInitialDeterministicSamplingIn(samplingRate int32) Option {
 	return newFuncOption(func(o *options) {
-		o.samplingIn = control.SamplingConfig{
+		o.initialConfig.SamplingIn = &control.SamplingConfig{
 			SamplingType: control.DeterministicSamplingType,
 			DeterministicSampling: control.DeterministicSamplingConfig{
 				SampleRate: samplingRate,

--- a/sampler/provider.go
+++ b/sampler/provider.go
@@ -83,10 +83,9 @@ func (p *Provider) Sampler(name string, schema defs.Schema) (defs.Sampler, error
 		ControlPlaneAddr: p.settings.ControlServerAddr,
 		EnableTLS:        p.opts.controlServerTLSEnable,
 
-		LimiterIn:  p.opts.limiterIn,
-		SamplingIn: p.opts.samplingIn,
-		Exporter:   p.sampleExporter,
-		LimiterOut: p.opts.limiterOut,
+		SamplingIn:    p.opts.samplingIn,
+		InitialConfig: p.opts.initialConfig,
+		Exporter:      p.sampleExporter,
 
 		UpdateStatsPeriod: p.opts.updateStatsPeriod,
 

--- a/sampler/provider.go
+++ b/sampler/provider.go
@@ -83,7 +83,6 @@ func (p *Provider) Sampler(name string, schema defs.Schema) (defs.Sampler, error
 		ControlPlaneAddr: p.settings.ControlServerAddr,
 		EnableTLS:        p.opts.controlServerTLSEnable,
 
-		SamplingIn:    p.opts.samplingIn,
 		InitialConfig: p.opts.initialConfig,
 		Exporter:      p.sampleExporter,
 

--- a/sampler/test/sampler_behavior_test.go
+++ b/sampler/test/sampler_behavior_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/neblic/platform/sampler"
 	"github.com/neblic/platform/sampler/defs"
 	otlpmock "github.com/neblic/platform/sampler/internal/sample/exporter/otlp/mock"
+	internalSampler "github.com/neblic/platform/sampler/internal/sampler"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ type nativeSample struct {
 	ID int
 }
 
-func sendSamplerConfigHandler(samplerConfig *protos.SamplerConfig, configured chan struct{}) func(protos.ControlPlane_SamplerConnServer) error {
+func sendSamplerConfigHandler(samplerConfig *protos.SamplerConfig) func(protos.ControlPlane_SamplerConnServer) error {
 	return func(stream protos.ControlPlane_SamplerConnServer) error {
 		err := stream.Send(&protos.ServerToSampler{
 			Message: &protos.ServerToSampler_ConfReq{
@@ -46,7 +47,6 @@ func sendSamplerConfigHandler(samplerConfig *protos.SamplerConfig, configured ch
 		Expect(reflect.TypeOf(samplerConfRes.GetMessage())).
 			To(Equal(reflect.TypeOf(&protos.SamplerToServer_ConfRes{})))
 
-		configured <- struct{}{}
 		return nil
 	}
 }
@@ -82,14 +82,7 @@ var _ = Describe("Sampler", func() {
 	Describe("Sampler initialization", func() {
 		When("default initial configuration is enabled", func() {
 			It("should create default stream and digest configurations", func() {
-				registered := make(chan struct{})
-				controlPlaneServer.SetSamplerHandlers(
-					mock.RegisterSamplerHandler,
-					func(stream protos.ControlPlane_SamplerConnServer) error {
-						registered <- struct{}{}
-						return nil
-					},
-				)
+				controlPlaneServer.SetSamplerHandlers(mock.RegisterSamplerHandler)
 				controlPlaneServer.Start(GinkgoT())
 
 				// initialize and start a sampler provider
@@ -102,29 +95,29 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				sampler, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// Wait until registration is performed
-				<-registered
+				// Wait until sampler has recieived the first configuration (with the default stream and digest)
+				require.Eventually(GinkgoT(),
+					func() bool {
+						defer GinkgoRecover()
 
-				sampled := sampler.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 1
+					},
+					time.Second, time.Millisecond*5,
+				)
+
+				sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
 				Expect(sampled).To(BeTrue())
 
-				Expect(sampler.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 
 		When("default initial configuration is disabled", func() {
 			It("should not create any stream nor digest configuration", func() {
-				registered := make(chan struct{})
-				controlPlaneServer.SetSamplerHandlers(
-					mock.RegisterSamplerHandler,
-					func(stream protos.ControlPlane_SamplerConnServer) error {
-						registered <- struct{}{}
-						return nil
-					},
-				)
+				controlPlaneServer.SetSamplerHandlers(mock.RegisterSamplerHandler)
 				controlPlaneServer.Start(GinkgoT())
 
 				// initialize and start a sampler provider
@@ -137,16 +130,23 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				sampler, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// Wait until registration is performed
-				<-registered
+				// Wait until sampler has received the initial configuration (empty)
+				require.Eventually(GinkgoT(),
+					func() bool {
+						defer GinkgoRecover()
 
-				sampled := sampler.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 1
+					},
+					time.Second, time.Millisecond*5,
+				)
+
+				sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
 				Expect(sampled).To(BeFalse())
 
-				Expect(sampler.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -154,13 +154,19 @@ var _ = Describe("Sampler", func() {
 	Describe("Not exporting samples", func() {
 		When("there isn't a matching rule", func() {
 			It("should not export samples", func() {
-				registered := make(chan struct{})
 				controlPlaneServer.SetSamplerHandlers(
 					mock.RegisterSamplerHandler,
-					func(stream protos.ControlPlane_SamplerConnServer) error {
-						registered <- struct{}{}
-						return nil
-					},
+					sendSamplerConfigHandler(
+						&protos.SamplerConfig{
+							Streams: []*protos.Stream{
+								{
+									Uid: uuid.NewString(),
+									Rule: &protos.Rule{
+										Language: protos.Rule_CEL, Expression: "sample.id==2",
+									},
+								},
+							},
+						}),
 				)
 				controlPlaneServer.Start(GinkgoT())
 
@@ -174,13 +180,23 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
+				require.Eventually(GinkgoT(),
+					func() bool {
+						defer GinkgoRecover()
+
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
+					},
+					time.Second, time.Millisecond*5,
+				)
+
+				sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
 				Expect(sampled).To(BeFalse())
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -190,7 +206,6 @@ var _ = Describe("Sampler", func() {
 			err      error
 			provider defs.Provider
 		)
-		configured := make(chan struct{})
 
 		BeforeEach(func() {
 			// configure and run a control plane server that registers the sampler and sends a configuration
@@ -206,7 +221,7 @@ var _ = Describe("Sampler", func() {
 								},
 							},
 						},
-					}, configured),
+					}),
 			)
 			controlPlaneServer.Start(GinkgoT())
 
@@ -223,23 +238,30 @@ var _ = Describe("Sampler", func() {
 		When("there is a matching rule but exporting raw samples is disabled", func() {
 			It("should not export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
+				require.Eventually(GinkgoT(),
+					func() bool {
+						defer GinkgoRecover()
+
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
+					},
+					time.Second, time.Millisecond*5,
+				)
 
 				// send samples to sampler
 				require.Never(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+						s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
 						return receiver.TotalItems.Load() >= 1
 					},
 					time.Millisecond*500, time.Millisecond)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -249,7 +271,6 @@ var _ = Describe("Sampler", func() {
 			err      error
 			provider defs.Provider
 		)
-		configured := make(chan struct{})
 
 		BeforeEach(func() {
 			// configure and run a control plane server that registers the sampler and sends a configuration
@@ -280,7 +301,7 @@ var _ = Describe("Sampler", func() {
 								ExportRawSamples: true,
 							},
 						},
-					}, configured),
+					}),
 			)
 			controlPlaneServer.Start(GinkgoT())
 
@@ -297,21 +318,22 @@ var _ = Describe("Sampler", func() {
 		When("there is a matching rule and", func() {
 			It("is a JSON sample it should export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until it is sampled
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
+
+				// send samples to sampler
+				sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+				Expect(sampled).To(BeTrue())
 
 				// the receiver should have received the sample
 				require.Eventually(GinkgoT(),
@@ -319,29 +341,29 @@ var _ = Describe("Sampler", func() {
 						defer GinkgoRecover()
 						return receiver.TotalItems.Load() == 1
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 
 			It("is a native sample it should export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until it is sampled
+				// wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.NativeSample(nativeSample{ID: 1}, ""))
-						Expect(err).ToNot(HaveOccurred())
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
+
+				// send sample
+				sampled := s.Sample(context.Background(), defs.NativeSample(nativeSample{ID: 1}, ""))
+				Expect(sampled).To(BeTrue())
 
 				// the receiver should have received the sample
 				require.Eventually(GinkgoT(),
@@ -349,31 +371,31 @@ var _ = Describe("Sampler", func() {
 						defer GinkgoRecover()
 						return receiver.TotalItems.Load() == 1
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 
 			It("is a proto sample it should export the sample", func() {
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.NewProtoSchema(&protos.SamplerToServer{}))
+				s, err := provider.Sampler("sampler1", defs.NewProtoSchema(&protos.SamplerToServer{}))
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until it is sampled
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.ProtoSample(&protos.SamplerToServer{SamplerUid: "1"}, ""))
-						Expect(err).ToNot(HaveOccurred())
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
 
-				// the receiver should have received the sample
+				// send sample
+				sampled := s.Sample(context.Background(), defs.ProtoSample(&protos.SamplerToServer{SamplerUid: "1"}, ""))
+				Expect(sampled).To(BeTrue())
+
+				// wait until the receiver has received the sample
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
@@ -381,14 +403,13 @@ var _ = Describe("Sampler", func() {
 					},
 					time.Second, time.Millisecond)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
 
 	Describe("Exporting digests", func() {
 		var settings sampler.Settings
-		configured := make(chan struct{})
 
 		BeforeEach(func() {
 			// configure and run a control plane server that registers the sampler and sends a configuration
@@ -414,7 +435,7 @@ var _ = Describe("Sampler", func() {
 							},
 						},
 					},
-				}, configured),
+				}),
 			)
 			controlPlaneServer.Start(GinkgoT())
 
@@ -436,19 +457,28 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := providerLimitedOut.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := providerLimitedOut.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until we receive a gigest
-				// we do this so we are sure the config has been read and applied by the sampler
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
+					},
+					time.Second, time.Millisecond*5,
+				)
+
+				// send sample
+				sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+				Expect(sampled).To(BeTrue())
+
+				// wait until the receiver has received the digest
+				require.Eventually(GinkgoT(),
+					func() bool {
+						defer GinkgoRecover()
+
 						totalItems := receiver.TotalItems.Load()
 						return totalItems >= 1
 					},
@@ -472,7 +502,6 @@ var _ = Describe("Sampler", func() {
 
 	Describe("Limiting exported samples", func() {
 		var settings sampler.Settings
-		configured := make(chan struct{})
 
 		BeforeEach(func() {
 			// configure and run a control plane server that registers the sampler and sends a configuration
@@ -488,7 +517,7 @@ var _ = Describe("Sampler", func() {
 							ExportRawSamples: true,
 						},
 					},
-				}, configured),
+				}),
 			)
 			controlPlaneServer.Start(GinkgoT())
 
@@ -510,44 +539,40 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := providerLimitedOut.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := providerLimitedOut.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until it is sampled
-				// we do this so we are sure the config has been read and applied by the sampler
+				// wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
 
 				// send a large amount of samples so the limiter kicks in
 				numSampled := 0
 				for i := 0; i < 1000; i++ {
-					sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+					sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
 
 					if sampled {
 						numSampled++
 					}
 				}
 
-				Expect(numSampled + 1).To(Equal(10))
+				Expect(numSampled).To(Equal(10))
 
 				// the receiver should have received the sample
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
-						return receiver.TotalItems.Load() == int32(numSampled+1)
+						return receiver.TotalItems.Load() == int32(numSampled)
 					},
 					time.Second, time.Millisecond)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 
@@ -561,44 +586,40 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := providerLimitedIn.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := providerLimitedIn.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until it is sampled
-				// we do this so we are sure the config has been read and applied by the sampler
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
 
 				// send a large amount of samples so the limiter kicks in
 				numSampled := 0
 				for i := 0; i < 1000; i++ {
-					sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
+					sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, ""))
 
 					if sampled {
 						numSampled++
 					}
 				}
 
-				Expect(numSampled + 1).To(Equal(5))
+				Expect(numSampled).To(Equal(5))
 
 				// the receiver should have received the sample
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
-						return receiver.TotalItems.Load() == int32(numSampled+1)
+						return receiver.TotalItems.Load() == int32(numSampled)
 					},
 					time.Second, time.Millisecond)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 
 		})
@@ -607,36 +628,32 @@ var _ = Describe("Sampler", func() {
 			It("should not export samples if their determinant is not selected", func() {
 				providerSampledIn, err := sampler.NewProvider(context.Background(), settings,
 					sampler.WithInitialLimiterInLimit(1000),
-					sampler.WithDeterministicSamplingIn(2),
+					sampler.WithInitialDeterministicSamplingIn(2),
 					sampler.WithInitialLimiterOutLimit(1000),
 					sampler.WithLogger(logger),
 					sampler.WithoutDefaultInitialConfig(),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				// create a sampler
-				p, err := providerSampledIn.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := providerSampledIn.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// wait until the server has configured the sampler
-				<-configured
-
-				// send samples to sampler until it is sampled
-				// we do this so we are sure the config has been read and applied by the sampler
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, "some_matching_key"))
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
 
 				// should not be sampled
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, "some_non_matching_key"))
+						sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, "some_non_matching_key"))
 						return !sampled
 					},
 					time.Second, time.Millisecond)
@@ -644,7 +661,7 @@ var _ = Describe("Sampler", func() {
 				// should all be sampled
 				numSampled := 0
 				for i := 0; i < 100; i++ {
-					sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, "some_matching_key"))
+					sampled := s.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, "some_matching_key"))
 
 					if sampled {
 						numSampled++
@@ -657,11 +674,11 @@ var _ = Describe("Sampler", func() {
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
-						return receiver.TotalItems.Load() == int32(numSampled+1)
+						return receiver.TotalItems.Load() == int32(numSampled)
 					},
 					time.Second, time.Millisecond)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -669,14 +686,9 @@ var _ = Describe("Sampler", func() {
 	Describe("Sending stats", func() {
 		When("the sampler is running", func() {
 			It("should send stats periodically", func() {
-				registered := make(chan struct{})
 				statsReceived := make(chan struct{})
 				controlPlaneServer.SetSamplerHandlers(
 					mock.RegisterSamplerHandler,
-					func(stream protos.ControlPlane_SamplerConnServer) error {
-						registered <- struct{}{}
-						return nil
-					},
 					func(stream protos.ControlPlane_SamplerConnServer) error {
 						stats, err := stream.Recv()
 						Expect(err).ShouldNot(HaveOccurred())
@@ -703,13 +715,22 @@ var _ = Describe("Sampler", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				<-registered
+				// Wait until sampler has received the initial configuration (empty)
+				require.Eventually(GinkgoT(),
+					func() bool {
+						defer GinkgoRecover()
+
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 1
+					},
+					time.Second, time.Millisecond*5,
+				)
+
 				<-statsReceived
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -717,7 +738,6 @@ var _ = Describe("Sampler", func() {
 	Describe("Forwarding errors", func() {
 		When("an error channel is provided", func() {
 			It("should forward errors to the channel", func() {
-				configured := make(chan struct{})
 
 				// start control plane server
 				controlPlaneServer.SetSamplerHandlers(
@@ -731,7 +751,7 @@ var _ = Describe("Sampler", func() {
 								},
 							},
 						},
-					}, configured),
+					}),
 				)
 				controlPlaneServer.Start(GinkgoT())
 
@@ -746,30 +766,27 @@ var _ = Describe("Sampler", func() {
 				provider, err := sampler.NewProvider(context.Background(), settings,
 					sampler.WithUpdateStatsPeriod(time.Second),
 					sampler.WithLogger(logger),
-					sampler.WithoutDefaultInitialConfig(),
 					sampler.WithSamplerErrorChannel(errCh),
+					sampler.WithoutDefaultInitialConfig(),
 				)
 				Expect(err).ToNot(HaveOccurred())
 
 				// create a sampler
-				p, err := provider.Sampler("sampler1", defs.DynamicSchema{})
+				s, err := provider.Sampler("sampler1", defs.DynamicSchema{})
 				Expect(err).ToNot(HaveOccurred())
 
-				<-configured
-
-				// send samples to sampler until it is sampled
-				// we do this so we are sure the config has been read and applied by the sampler
+				// Wait until sampler has received the initial configuration (empty) and the posterior update
 				require.Eventually(GinkgoT(),
 					func() bool {
 						defer GinkgoRecover()
 
-						sampled := p.Sample(context.Background(), defs.JSONSample(`{"id": 1}`, "some_matching_key"))
-						return sampled
+						return s.(*internalSampler.Sampler).ConfigUpdates() == 2
 					},
-					time.Second, time.Millisecond)
+					time.Second, time.Millisecond*5,
+				)
 
 				// send an invalid sample
-				sampled := p.Sample(context.Background(), defs.JSONSample(`invalid_json: `, ""))
+				sampled := s.Sample(context.Background(), defs.JSONSample(`invalid_json: `, ""))
 				Expect(sampled).To(BeFalse())
 
 				/// expect an error to be received
@@ -780,7 +797,7 @@ var _ = Describe("Sampler", func() {
 					},
 					time.Second, time.Millisecond)
 
-				Expect(p.Close()).ToNot(HaveOccurred())
+				Expect(s.Close()).ToNot(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
## Describe your changes
The main changes in this PR are to automatically create a default stream and digest the first time a sampler is registered (posterior registrations don't affect the configuration). The current implementation of the sampler is configuring the limiters and sampling at startup using the user code sampler configuration (it does not wait until a reconcile happens and a configuration of the sampler is sent by the server). As a result, there is some time between the startup and the receival of the first config where wrong configuration could be used. With the addition of stream and digest configuration at strartup, this could be more problematic, as we could generate data when we don't want. For that reason the behaviour was changed, so the sampler waits until the first reconciliation configuration is received until it starts processing data (all the other data gets skipped)

Features:
- Sampler automatically creates an `all` stream with `true` expression and not exporting raw data
- Sampler automatically creates an `all` structure digest that sends data every minute
- Sampler waits until a configuration from the server is received to start processing data
- Controlplane receives initial configuration from the sampler at startup, if it's the first time a sampler has registered for the given `resource` and `sampler`, the provided initial configuration is used. Otherwise, the stored configuration is used
- As sampler propagates the initial limiter in, sampler in, and limiter out configuration. This values can now be seen in neblictl and in the propagated configuration (before, only the neblictl overrides could be seen)
- neblictl shows correct limiter in, sampler in and limiter out configuration
- Limiter in, limiter out and sampling configuration provided when initializing a sampler in code approach has been changed to the new standard. As a result of that, `WithInitialLimiterInLimit`, `WithInitialLimiterOutLimit` and `WithInitialDeterministicSamplingIn` functions were created. `WithLimiterInLimit`, `WithLimiterOutLimit` and `WithDeterministicSamplingIn` are still present but, they are deprecated.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
