### PR TITLE
"fix(sampler): do not close provider exporter when closing sampler" and kafka-sampler improvements

### DIFF
--- a/cmd/kafka-sampler/README.md
+++ b/cmd/kafka-sampler/README.md
@@ -2,7 +2,7 @@
 
 <!--learn-start-->
 <!-- ### Kafka -->
-Neblic provides a standalone service called `kafk-sampler` capable of automatically monitoring your `Apache Kafka` topics and creating `Samplers` that will allow you to inspect all data that flows through them.
+Neblic provides a standalone service called `kafka-sampler` capable of automatically monitoring your `Apache Kafka` topics and creating `Samplers` that will allow you to inspect all data that flows through them.
 
 #### Supported encodings
 
@@ -18,7 +18,7 @@ See the [releases](https://github.com/neblic/platform/releases) page to download
 
 ## Usage
 
-On startup, it will subscribe to all or a subset (based on your configuration) of your Kafka topics and create a `Sampler` per each one. No other actions are required since it will automatically register the `Samplers` with the `Control Plane` server and keep the list of `Samplers` updated if topics are added or removed.
+On startup, it will subscribe to all or a subset (based on your configuration) of your Kafka topics and create a `Sampler` per each one. No other actions are required since it will automatically register the `Samplers` with Neblic's `Control Plane` server and keep the list of `Samplers` updated if topics are added or removed.
 <!--how-to-end-->
 
 <!--ref-start-->

--- a/cmd/kafka-sampler/app.go
+++ b/cmd/kafka-sampler/app.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/neblic/platform/cmd/kafka-sampler/kafka"
-	"github.com/neblic/platform/cmd/kafka-sampler/kafka/sarama"
 	"github.com/neblic/platform/logging"
 )
 
@@ -14,15 +13,10 @@ type KafkaSampler struct {
 	ctx             context.Context
 	logger          logging.Logger
 	config          *Config
-	client          kafka.Client
 	consumerManager *kafka.ConsumerManager
 }
 
 func NewKafkaSampler(ctx context.Context, logger logging.Logger, config *Config) (*KafkaSampler, error) {
-	client, err := sarama.NewClient(config.Kafka.Servers, &config.Kafka.Sarama)
-	if err != nil {
-		return nil, err
-	}
 	consumerManager, err := kafka.NewConsumerManager(ctx, logger, &config.Kafka)
 	if err != nil {
 		return nil, err
@@ -32,7 +26,6 @@ func NewKafkaSampler(ctx context.Context, logger logging.Logger, config *Config)
 		ctx:             ctx,
 		logger:          logger,
 		config:          config,
-		client:          client,
 		consumerManager: consumerManager,
 	}
 

--- a/cmd/kafka-sampler/app.go
+++ b/cmd/kafka-sampler/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/neblic/platform/cmd/kafka-sampler/kafka"
@@ -48,13 +49,15 @@ func (r *KafkaSampler) Run() error {
 	}
 
 	// In case of having a reconcile period of 0 nanoseconds, disable it
-	if r.config.ReconcilePeriod == 0 {
+	if r.config.Kafka.TopicFilter.RefreshPeriod == 0 {
+		r.logger.Info("Reconciliation period is 0, disabling reconciliation. Added/deleted topics won't be detected.")
+
 		<-r.ctx.Done()
 		return nil
 	}
 
-	// Execute periodic reconcilitaions
-	ticker := time.NewTicker(r.config.ReconcilePeriod)
+	// Execute periodic reconciliations
+	ticker := time.NewTicker(r.config.Kafka.TopicFilter.RefreshPeriod)
 	for {
 		select {
 		case <-r.ctx.Done():

--- a/cmd/kafka-sampler/app.go
+++ b/cmd/kafka-sampler/app.go
@@ -19,7 +19,7 @@ type KafkaSampler struct {
 func NewKafkaSampler(ctx context.Context, logger logging.Logger, config *Config) (*KafkaSampler, error) {
 	consumerManager, err := kafka.NewConsumerManager(ctx, logger, &config.Kafka)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating kafka consumer manager: %w", err)
 	}
 
 	kafkaSampler := &KafkaSampler{
@@ -33,9 +33,7 @@ func NewKafkaSampler(ctx context.Context, logger logging.Logger, config *Config)
 }
 
 func (r *KafkaSampler) Run() error {
-
 	// Run first reconciliation
-	r.logger.Info("Running reconcilitation")
 	err := r.consumerManager.Reconcile()
 	if err != nil {
 		return err
@@ -56,10 +54,9 @@ func (r *KafkaSampler) Run() error {
 		case <-r.ctx.Done():
 			return nil
 		case <-ticker.C:
-			r.logger.Info("Running reconcilitation")
 			err := r.consumerManager.Reconcile()
 			if err != nil {
-				r.logger.Error("Error running reconciliation", "error", err)
+				r.logger.Error("Error running reconciliation, it will continue trying", "error", err)
 			}
 		}
 	}

--- a/cmd/kafka-sampler/config.go
+++ b/cmd/kafka-sampler/config.go
@@ -1,24 +1,26 @@
 package main
 
 import (
-	"time"
-
 	"github.com/neblic/platform/cmd/kafka-sampler/kafka"
 	"github.com/neblic/platform/cmd/kafka-sampler/neblic"
 )
 
+type LoggingConfig struct {
+	Level string
+}
+
 type Config struct {
-	Verbose         bool
-	Kafka           kafka.Config
-	Neblic          neblic.Config
-	ReconcilePeriod time.Duration
+	Logging LoggingConfig
+	Kafka   kafka.Config
+	Neblic  neblic.Config
 }
 
 func NewConfig() *Config {
 	return &Config{
-		Verbose:         false,
-		Kafka:           *kafka.NewConfig(),
-		Neblic:          *neblic.NewConfig(),
-		ReconcilePeriod: time.Minute,
+		Logging: LoggingConfig{
+			Level: "info",
+		},
+		Kafka:  *kafka.NewConfig(),
+		Neblic: *neblic.NewConfig(),
 	}
 }

--- a/cmd/kafka-sampler/filter/config.go
+++ b/cmd/kafka-sampler/filter/config.go
@@ -1,13 +1,17 @@
 package filter
 
+import "time"
+
 type Config struct {
-	Allowlist Predicates
-	Denylist  Predicates
+	RefreshPeriod time.Duration
+	Allowlist     Predicates
+	Denylist      Predicates
 }
 
 func NewConfig() *Config {
 	return &Config{
-		Allowlist: Predicates{},
-		Denylist:  Predicates{},
+		RefreshPeriod: time.Minute,
+		Allowlist:     Predicates{},
+		Denylist:      Predicates{},
 	}
 }

--- a/cmd/kafka-sampler/filter/filter.go
+++ b/cmd/kafka-sampler/filter/filter.go
@@ -1,6 +1,6 @@
 package filter
 
-import "fmt"
+import "errors"
 
 type Filter struct {
 	predicates []Predicate
@@ -37,7 +37,7 @@ func denylistEvalFunc(predicates []Predicate, element string) bool {
 
 func New(config *Config) (*Filter, error) {
 	if len(config.Allowlist) > 0 && len(config.Denylist) > 0 {
-		return nil, fmt.Errorf("allowlist and denylist at the same time is not supported. Specify one of the two")
+		return nil, errors.New("allowlist and denylist at the same time is not supported. Specify one of the two")
 	}
 
 	var predicates []Predicate

--- a/cmd/kafka-sampler/kafka/config.go
+++ b/cmd/kafka-sampler/kafka/config.go
@@ -15,7 +15,7 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		Servers:       []string{"localhost:9092"},
-		ConsumerGroup: "kafkasampler",
+		ConsumerGroup: "neblic-kafka-sampler",
 		Sarama:        *sarama.NewConfig(),
 		TopicFilter:   *filter.NewConfig(),
 	}

--- a/cmd/kafka-sampler/kafka/consumer_manager.go
+++ b/cmd/kafka-sampler/kafka/consumer_manager.go
@@ -121,7 +121,7 @@ func (m *ConsumerManager) reconcile(topics []string) error {
 				continue
 			}
 
-			// Initalize consumer
+			// Initialize consumer
 			ctx, cancel := context.WithCancel(m.ctx)
 			consumerInstance := &consumerInstance{
 				wg:     sync.WaitGroup{},

--- a/cmd/kafka-sampler/kafka/consumer_manager_behaviour_test.go
+++ b/cmd/kafka-sampler/kafka/consumer_manager_behaviour_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Manager behaviour", func() {
 			logger: logger,
 			config: NewConfig(),
 			client: client,
-			groupProvider: func() (ConsumerGroup, error) {
+			groupProvider: func(topic string) (ConsumerGroup, error) {
 				group := mock_kafka.NewMockConsumerGroup(mockCtrl)
 				group.EXPECT().Consume(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 				group.EXPECT().Close().AnyTimes().Return(nil)

--- a/cmd/kafka-sampler/kafka/sarama/client.go
+++ b/cmd/kafka-sampler/kafka/sarama/client.go
@@ -10,9 +10,6 @@ type Client struct {
 }
 
 func NewClient(servers []string, config *Config) (*Client, error) {
-	config.Metadata.RefreshFrequency = 0
-	config.Metadata.Full = false
-
 	c, err := sarama.NewClient(servers, config)
 
 	return &Client{

--- a/cmd/kafka-sampler/kafka/sarama/client.go
+++ b/cmd/kafka-sampler/kafka/sarama/client.go
@@ -1,6 +1,8 @@
 package sarama
 
 import (
+	"fmt"
+
 	"github.com/Shopify/sarama"
 )
 
@@ -11,9 +13,12 @@ type Client struct {
 
 func NewClient(servers []string, config *Config) (*Client, error) {
 	c, err := sarama.NewClient(servers, config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating sarama kafka client: %w", err)
+	}
 
 	return &Client{
 		config: config,
 		Client: c,
-	}, err
+	}, nil
 }

--- a/cmd/kafka-sampler/kafka/sarama/config.go
+++ b/cmd/kafka-sampler/kafka/sarama/config.go
@@ -5,5 +5,12 @@ import "github.com/Shopify/sarama"
 type Config = sarama.Config
 
 func NewConfig() *Config {
-	return sarama.NewConfig()
+	c := sarama.NewConfig()
+
+	// Setting default configuration
+	c.Metadata.RefreshFrequency = 0
+	c.Metadata.Full = false
+	c.ClientID = "neblic-kafka-sampler"
+
+	return c
 }

--- a/cmd/kafka-sampler/kafka/sarama/consumer_group.go
+++ b/cmd/kafka-sampler/kafka/sarama/consumer_group.go
@@ -2,6 +2,7 @@ package sarama
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Shopify/sarama"
 	"github.com/neblic/platform/logging"
@@ -15,7 +16,7 @@ type ConsumerGroup struct {
 func NewConsumerGroup(logger logging.Logger, servers []string, groupID string, config *Config) (*ConsumerGroup, error) {
 	group, err := sarama.NewConsumerGroup(servers, groupID, config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating saram kafka consumer group: %w", err)
 	}
 
 	return &ConsumerGroup{

--- a/cmd/kafka-sampler/main.go
+++ b/cmd/kafka-sampler/main.go
@@ -107,7 +107,7 @@ func initNeblic(ctx context.Context, logger logging.Logger, config *neblic.Confi
 		options = append(options, sampler.WithTLS())
 	}
 	if config.LimiterOutLimit != 0 {
-		options = append(options, sampler.WithLimiterOutLimit(int32(config.LimiterOutLimit)))
+		options = append(options, sampler.WithInitialLimiterOutLimit(int32(config.LimiterOutLimit)))
 	}
 	if config.UpdateStatsPeriod != 0 {
 		options = append(options, sampler.WithUpdateStatsPeriod(config.UpdateStatsPeriod))

--- a/cmd/kafka-sampler/main.go
+++ b/cmd/kafka-sampler/main.go
@@ -143,7 +143,11 @@ func main() {
 	flag.Parse()
 
 	config := initConfig(configPath)
-	logger, _ := logging.NewZapDev()
+	logger, err := logging.NewZapProd(config.Logging.Level)
+	if err != nil {
+		log.Fatalf("Error initializing logger: %v", err)
+	}
+	defer logger.ZapLogger().Sync()
 
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/kafka-sampler/neblic/config.go
+++ b/cmd/kafka-sampler/neblic/config.go
@@ -21,7 +21,7 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		Settings: sampler.Settings{
-			ResourceName:      "kafkasampler",
+			ResourceName:      "kafka-sampler",
 			ControlServerAddr: "localhost:8899",
 			DataServerAddr:    "localhost:4317",
 		},

--- a/cmd/neblictl/main.go
+++ b/cmd/neblictl/main.go
@@ -32,6 +32,8 @@ var (
 	originalTermios      *unix.Termios = &unix.Termios{}
 )
 
+const logLevel = "debug"
+
 func createTokanizedCommand(inputText string, cursorPos int) *interpoler.TokanizedCommand {
 	parts := strings.Split(inputText, " ")
 
@@ -116,10 +118,11 @@ func fail(format string, a ...any) {
 
 func main() {
 	// Initialize logger
-	logger, err := logging.NewZapDev()
+	logger, err := logging.NewZapProd(logLevel)
 	if err != nil {
 		fail(err.Error())
 	}
+	defer logger.ZapLogger().Sync()
 
 	// Initialize configuration controller
 	configController, err := internal.NewConfigurationController()

--- a/dist/kafka-sampler/config.yaml
+++ b/dist/kafka-sampler/config.yaml
@@ -1,35 +1,35 @@
-verbose: true
+logging:
+  level: info
 
-# optional: Topic list refresh period. In each refresh it will create/delete `Samplers` based on the cluster existing topics
-# reconcileperiod: 1m
-
-# Kafka related options
 kafka:
   # required: Kafka bootstrap addresses, format "url1:port,url2:port".
   servers: kafka:9092
 
-  # optional: consumer group that the Kafka consumers will use
-  # consumergroup: kafkasampler
+  # Consumer group that the Kafka consumers will use
+  # consumergroup: neblic-kafka-sampler
 
+  # Kafka configuration as defined in the Sarama library
   # https://pkg.go.dev/github.com/shopify/sarama#Config
-  # all lowercase and nested structs divided with `_`
+  # Convert field names to all lowercase and divide nested structs with `_`
   # sarama:  (...)
 
-  # optional: if unset, it will create a Sampler per each topic found in the Kafka cluster
+  # If unset, it will create a `Sampler` per each topic found in the Kafka cluster,
+  # supports regex RE2 syntax as described at https://github.com/google/re2/wiki/Syntax, except for `\C`.
+  # It always ignores internal topics like: `__consumer_offsets` and `__transaction_state`.
   # topicfilter: 
+  #   # Topic list refresh period. In each refresh it will create/delete `Samplers` based on the cluster existing topics
+  #   refreshperiod: 1m
+  #   # Topics matching `allowlist` will be monitored, and topics matching `denylist` will be ignored.
+  #   # `allowlist` and `denylist` can't be set at the same time.
   #   allowlist:
   #   denylist:
 
-# Neblic related options
 neblic:
-  # optional: `Sampler` resource name set to created `Samplers` 
+  # `Sampler` resource name set to created `Samplers`
   # resourcename: kafka-sampler
 
-  # optional: `Control Plane` server address
+  # `Control Plane` server address
   # controlserveraddr: localhost:8899
 
-  # optional: `Data Plane` server address
-  # dataserveraddrL localhost:4317
-
-  # optional: `Sampler` update stats period option
-  # updatestatsperiod: 15s
+  # `Data Plane` server address
+  # dataserveraddr: localhost:4317

--- a/sampler/internal/sampler/sampler.go
+++ b/sampler/internal/sampler/sampler.go
@@ -357,9 +357,5 @@ func (p *Sampler) Close() error {
 		return fmt.Errorf("error closing control plane client: %w", err)
 	}
 
-	if err := p.exporter.Close(context.Background()); err != nil {
-		return fmt.Errorf("error closing samples dp. %w", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

The exporter should be closed when closing the provider, not the sampler, to avoid closing it when there are still samplers using it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
