### PR TITLE
feat(neblictl): hide digests computation location parameter

### DIFF
--- a/cmd/neblictl/internal/controlplane/commands.go
+++ b/cmd/neblictl/internal/controlplane/commands.go
@@ -450,13 +450,6 @@ func NewCommands(controlPlaneExecutors *Executors, controlPlaneCompleters *Compl
 						Default:     "100",
 					},
 					{
-						Name:        "computation-location",
-						Description: "Where the computation of the struct digest must take place. Possible values are: sampler and collector",
-						Completer:   controlPlaneCompleters.ListComputationLocation,
-						Optional:    true,
-						Default:     "sampler",
-					},
-					{
 						Name:        "resource-name",
 						Description: "Filter by resource",
 						Completer:   controlPlaneCompleters.ListResourcesUID,
@@ -503,13 +496,6 @@ func NewCommands(controlPlaneExecutors *Executors, controlPlaneCompleters *Compl
 						Default:     "100",
 					},
 					{
-						Name:        "computation-location",
-						Description: "Where the computation of the struct digest must take place. Possible values are: sampler and collector",
-						Completer:   controlPlaneCompleters.ListComputationLocation,
-						Optional:    true,
-						Default:     "sampler",
-					},
-					{
 						Name:        "resource-name",
 						Description: "Filter by resource",
 						Filter:      true,
@@ -554,13 +540,6 @@ func NewCommands(controlPlaneExecutors *Executors, controlPlaneCompleters *Compl
 						Default:     "100",
 					},
 					{
-						Name:        "computation-location",
-						Description: "Where the computation of the value digest must take place. Possible values are: sampler and collector",
-						Completer:   controlPlaneCompleters.ListComputationLocation,
-						Optional:    true,
-						Default:     "sampler",
-					},
-					{
 						Name:        "resource-name",
 						Description: "Filter by resource",
 						Completer:   controlPlaneCompleters.ListResourcesUID,
@@ -602,13 +581,6 @@ func NewCommands(controlPlaneExecutors *Executors, controlPlaneCompleters *Compl
 						Description: "Maximum number of fields to process when processing a sample",
 						Optional:    true,
 						Default:     "100",
-					},
-					{
-						Name:        "computation-location",
-						Description: "Where the computation of the value digest must take place. Possible values are: sampler and collector",
-						Completer:   controlPlaneCompleters.ListComputationLocation,
-						Optional:    true,
-						Default:     "sampler",
 					},
 					{
 						Name:        "resource-name",

--- a/cmd/neblictl/internal/controlplane/completers.go
+++ b/cmd/neblictl/internal/controlplane/completers.go
@@ -170,7 +170,3 @@ func (c *Completers) ListEventsName(ctx context.Context, parameters interpoler.P
 
 	return eventsName
 }
-
-func (c *Completers) ListComputationLocation(ctx context.Context, parameters interpoler.ParametersWithValue) []string {
-	return []string{control.ComputationLocationSampler.String(), control.ComputationLocationCollector.String()}
-}

--- a/cmd/neblictl/internal/controlplane/executors.go
+++ b/cmd/neblictl/internal/controlplane/executors.go
@@ -467,11 +467,7 @@ func (e *Executors) DigestsStructureCreate(ctx context.Context, parameters inter
 		return fmt.Errorf("flush-period must be an integer")
 	}
 
-	computationLocationParameter, _ := parameters.Get("computation-location")
-	computationLocation := control.ParseComputationLocation(computationLocationParameter.Value)
-	if computationLocation == control.ComputationLocationUnknown {
-		return fmt.Errorf("computation-location not supported")
-	}
+	computationLocation := control.ComputationLocationSampler
 
 	updateGen := func(samplerControl *control.Sampler) (*control.SamplerConfigUpdate, error) {
 
@@ -486,7 +482,7 @@ func (e *Executors) DigestsStructureCreate(ctx context.Context, parameters inter
 		}
 
 		if computationLocation == control.ComputationLocationCollector && !stream.ExportRawSamples {
-			return nil, fmt.Errorf("Stream must export raw samples to use collector computation location")
+			return nil, fmt.Errorf("Stream must export raw samples to be able to compute struct digests")
 		}
 
 		return &control.SamplerConfigUpdate{
@@ -528,11 +524,7 @@ func (e *Executors) DigestsStructureUpdate(ctx context.Context, parameters inter
 		return fmt.Errorf("flush-period must be an integer")
 	}
 
-	computationLocationParameter, _ := parameters.Get("computation-location")
-	computationLocation := control.ParseComputationLocation(computationLocationParameter.Value)
-	if computationLocation == control.ComputationLocationUnknown {
-		return fmt.Errorf("computation-location not supported")
-	}
+	computationLocation := control.ComputationLocationSampler
 
 	updateGen := func(samplerControl *control.Sampler) (*control.SamplerConfigUpdate, error) {
 
@@ -547,7 +539,7 @@ func (e *Executors) DigestsStructureUpdate(ctx context.Context, parameters inter
 		}
 
 		if computationLocation == control.ComputationLocationCollector && !stream.ExportRawSamples {
-			return nil, fmt.Errorf("Stream must export raw samples to use collector computation location")
+			return nil, fmt.Errorf("Stream must export raw samples to be able to compute struct digests")
 		}
 
 		return &control.SamplerConfigUpdate{
@@ -590,11 +582,7 @@ func (e *Executors) DigestsValueCreate(ctx context.Context, parameters interpole
 		return fmt.Errorf("flush-period must be an integer")
 	}
 
-	computationLocationParameter, _ := parameters.Get("computation-location")
-	computationLocation := control.ParseComputationLocation(computationLocationParameter.Value)
-	if computationLocation == control.ComputationLocationUnknown {
-		return fmt.Errorf("computation-location not supported")
-	}
+	computationLocation := control.ComputationLocationCollector
 
 	updateGen := func(samplerControl *control.Sampler) (*control.SamplerConfigUpdate, error) {
 
@@ -609,7 +597,7 @@ func (e *Executors) DigestsValueCreate(ctx context.Context, parameters interpole
 		}
 
 		if computationLocation == control.ComputationLocationCollector && !stream.ExportRawSamples {
-			return nil, fmt.Errorf("Stream must export raw samples to use collector computation location")
+			return nil, fmt.Errorf("Stream must export raw samples to be able to compute value digests")
 		}
 
 		return &control.SamplerConfigUpdate{
@@ -651,11 +639,7 @@ func (e *Executors) DigestsValueUpdate(ctx context.Context, parameters interpole
 		return fmt.Errorf("flush-period must be an integer")
 	}
 
-	computationLocationParameter, _ := parameters.Get("computation-location")
-	computationLocation := control.ParseComputationLocation(computationLocationParameter.Value)
-	if computationLocation == control.ComputationLocationUnknown {
-		return fmt.Errorf("computation-location not supported")
-	}
+	computationLocation := control.ComputationLocationCollector
 
 	updateGen := func(samplerControl *control.Sampler) (*control.SamplerConfigUpdate, error) {
 
@@ -670,7 +654,7 @@ func (e *Executors) DigestsValueUpdate(ctx context.Context, parameters interpole
 		}
 
 		if computationLocation == control.ComputationLocationCollector && !stream.ExportRawSamples {
-			return nil, fmt.Errorf("Stream must export raw samples to use collector computation location")
+			return nil, fmt.Errorf("Stream must export raw samples to be able to compute value digests")
 		}
 
 		return &control.SamplerConfigUpdate{


### PR DESCRIPTION
## Describe your changes
Digests computation location is hidden from the user when using neblictl.
- Struct digests are computed in the sampler
- Value digests are computed in the collector

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have made the appropriate changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] If it is a major user facing functionality, I have added behavioural tests
- [X] If it is a critical part of the code or of significant complexity, I have added thorough testing
