### PR TITLE
feat(kafkasampler): add max topics to process

### DIFF
--- a/cmd/kafka-sampler/app.go
+++ b/cmd/kafka-sampler/app.go
@@ -40,7 +40,7 @@ func (r *KafkaSampler) Run() error {
 	}
 
 	// In case of having a reconcile period of 0 nanoseconds, disable it
-	if r.config.Kafka.TopicFilter.RefreshPeriod == 0 {
+	if r.config.Kafka.Topics.RefreshPeriod == 0 {
 		r.logger.Warn("Topic refresh period is 0. Added/deleted topics won't be detected.")
 
 		<-r.ctx.Done()
@@ -48,7 +48,7 @@ func (r *KafkaSampler) Run() error {
 	}
 
 	// Execute periodic reconciliations
-	ticker := time.NewTicker(r.config.Kafka.TopicFilter.RefreshPeriod)
+	ticker := time.NewTicker(r.config.Kafka.Topics.RefreshPeriod)
 	for {
 		select {
 		case <-r.ctx.Done():

--- a/cmd/kafka-sampler/filter/config.go
+++ b/cmd/kafka-sampler/filter/config.go
@@ -1,17 +1,13 @@
 package filter
 
-import "time"
-
 type Config struct {
-	RefreshPeriod time.Duration
-	Allowlist     Predicates
-	Denylist      Predicates
+	Allowlist Predicates
+	Denylist  Predicates
 }
 
 func NewConfig() *Config {
 	return &Config{
-		RefreshPeriod: time.Minute,
-		Allowlist:     Predicates{},
-		Denylist:      Predicates{},
+		Allowlist: Predicates{},
+		Denylist:  Predicates{},
 	}
 }

--- a/cmd/kafka-sampler/kafka/config.go
+++ b/cmd/kafka-sampler/kafka/config.go
@@ -1,15 +1,23 @@
 package kafka
 
 import (
+	"time"
+
 	"github.com/neblic/platform/cmd/kafka-sampler/filter"
 	"github.com/neblic/platform/cmd/kafka-sampler/kafka/sarama"
 )
+
+type TopicsConfig struct {
+	Max           int
+	RefreshPeriod time.Duration
+	Filter        filter.Config
+}
 
 type Config struct {
 	Servers       []string
 	ConsumerGroup string
 	Sarama        sarama.Config
-	TopicFilter   filter.Config
+	Topics        TopicsConfig
 }
 
 func NewConfig() *Config {
@@ -17,6 +25,10 @@ func NewConfig() *Config {
 		Servers:       []string{"localhost:9092"},
 		ConsumerGroup: "neblic-kafka-sampler",
 		Sarama:        *sarama.NewConfig(),
-		TopicFilter:   *filter.NewConfig(),
+		Topics: TopicsConfig{
+			Max:           25,
+			RefreshPeriod: time.Minute,
+			Filter:        *filter.NewConfig(),
+		},
 	}
 }

--- a/dist/kafka-sampler/config.yaml
+++ b/dist/kafka-sampler/config.yaml
@@ -13,10 +13,9 @@ kafka:
   # Convert field names to all lowercase and divide nested structs with `_`
   # sarama:  (...)
 
-  # Topics contains all the configuration about the topics that have to be read from
   # topics:
-  #   # Maximum number of topics to read from (safeguard). Topics after the limit is reached
-  #   # are ignored
+  #   # Safeguard to avoid consuming an unexpectedly large number of topics.
+  #   # The first max number of topics that match the filter rules (in no particular order) will be monitored, the rest will be ignored.
   #   max: 25
   #
   #   # Topic list refresh period. In each refresh it will create/delete `Samplers` based on the cluster existing topics
@@ -25,7 +24,7 @@ kafka:
   #   # If unset, it will create a `Sampler` per each topic found in the Kafka cluster,
   #   # supports regex RE2 syntax as described at https://github.com/google/re2/wiki/Syntax, except for `\C`.
   #   # It always ignores internal topics like: `__consumer_offsets` and `__transaction_state`.
-  #   topicfilter:
+  #   filter:
   #     # Topics matching `allowlist` will be monitored, and topics matching `denylist` will be ignored.
   #     # `allowlist` and `denylist` can't be set at the same time.
   #     allowlist:

--- a/dist/kafka-sampler/config.yaml
+++ b/dist/kafka-sampler/config.yaml
@@ -13,16 +13,23 @@ kafka:
   # Convert field names to all lowercase and divide nested structs with `_`
   # sarama:  (...)
 
-  # If unset, it will create a `Sampler` per each topic found in the Kafka cluster,
-  # supports regex RE2 syntax as described at https://github.com/google/re2/wiki/Syntax, except for `\C`.
-  # It always ignores internal topics like: `__consumer_offsets` and `__transaction_state`.
-  # topicfilter: 
+  # Topics contains all the configuration about the topics that have to be read from
+  # topics:
+  #   # Maximum number of topics to read from (safeguard). Topics after the limit is reached
+  #   # are ignored
+  #   max: 25
+  #
   #   # Topic list refresh period. In each refresh it will create/delete `Samplers` based on the cluster existing topics
   #   refreshperiod: 1m
-  #   # Topics matching `allowlist` will be monitored, and topics matching `denylist` will be ignored.
-  #   # `allowlist` and `denylist` can't be set at the same time.
-  #   allowlist:
-  #   denylist:
+  #
+  #   # If unset, it will create a `Sampler` per each topic found in the Kafka cluster,
+  #   # supports regex RE2 syntax as described at https://github.com/google/re2/wiki/Syntax, except for `\C`.
+  #   # It always ignores internal topics like: `__consumer_offsets` and `__transaction_state`.
+  #   topicfilter:
+  #     # Topics matching `allowlist` will be monitored, and topics matching `denylist` will be ignored.
+  #     # `allowlist` and `denylist` can't be set at the same time.
+  #     allowlist:
+  #     denylist:
 
 neblic:
   # `Sampler` resource name set to created `Samplers`


### PR DESCRIPTION
## Describe your changes
Add safeguard reading topics to avoid reading from hundreds of topics at the same time without wanting to do that

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
