### PR TITLE
build: use PAT token on releases

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -29,4 +29,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_RELEASER }}


### PR DESCRIPTION
## Describe your changes

Fixes docs not building when creating a release due to using the GITHUB_TOKEN secret
