### PR TITLE
feat(neblictl): return error when creating/updating an event with disabled export raw samples

### DIFF
--- a/cmd/neblictl/internal/controlplane/executors.go
+++ b/cmd/neblictl/internal/controlplane/executors.go
@@ -750,6 +750,10 @@ func (e *Executors) EventsCreate(ctx context.Context, parameters interpoler.Para
 			return nil, fmt.Errorf("Stream does not exist")
 		}
 
+		if !stream.ExportRawSamples {
+			return nil, fmt.Errorf("Stream must export raw samples to be able to compute events")
+		}
+
 		return &control.SamplerConfigUpdate{
 			EventUpdates: []control.EventUpdate{
 				{
@@ -796,6 +800,10 @@ func (e *Executors) EventsUpdate(ctx context.Context, parameters interpoler.Para
 		stream, ok := getEntryByName(samplerControl.Config.Streams, streamNameParameter.Value)
 		if !ok {
 			return nil, fmt.Errorf("Stream does not exist")
+		}
+
+		if !stream.ExportRawSamples {
+			return nil, fmt.Errorf("Stream must export raw samples to be able to compute events")
 		}
 
 		return &control.SamplerConfigUpdate{


### PR DESCRIPTION
Return error when creating/updating an event with a stream that does not have export raw samples enabled

## Describe your changes

Fixes # (issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
