### PR TITLE
fix(kafkasampler): SASL/SCRAM support

### DIFF
--- a/cmd/kafka-sampler/README.md
+++ b/cmd/kafka-sampler/README.md
@@ -38,15 +38,60 @@ For now, only `x86-64` builds are offered. If you need another architecture you 
 
 ## Usage
 
-On startup, it will subscribe to all or a subset (based on your configuration) of your Kafka topics and create a `Sampler` per each one. No other actions are required since it will automatically register the `Samplers` with Neblic's `Control Plane` server and keep the list of `Samplers` updated if topics are added or removed.
+On startup, it will subscribe to all or a subset (based on your configuration, see the [reference](https://docs.neblic.com/latest/reference/kafka-sampler/) page) of your Kafka topics and create a `Sampler` per each one. No other actions are required since it will automatically register the `Samplers` with Neblic's `Control Plane` server and keep the list of `Samplers` updated if topics are added or removed.
 <!--how-to-end-->
 
 <!--ref-start-->
 ## Configuration 
 
-By default, `kafka-sampler` will look for a config file at `/etc/neblic/kafka-sampler/config.yaml`. This path can be changed using the `--config` flag when executing the service.
+By default, `kafka-sampler` will look for a configuration file at `/etc/neblic/kafka-sampler/config.yaml`. This path can be changed using the `--config` flag when executing the service.
 
-All the options defined in the configuration file can be configured/overridden using environment variables. The environment variable name needs to be written in all caps and use `_` to divide nested objects. For example, to configure the Kafka server URL you would need to use the env variable `KAFKA_SERVERS` or to configure the filters `KAFKA_TOPICS_FILTER_ALLOW`.
+All the options defined in the configuration file can be configured/overridden using environment variables. The environment variable name needs to be written in all caps and use `_` to divide nested objects. For example, to configure the Kafka server URL you would need to use the env variable `KAFKA_SERVERS`.
+
+Internally, `kafka-sampler` uses the [`Sarama`](https://github.com/IBM/sarama/) Go library to interact with Kafka and all its [options](https://pkg.go.dev/github.com/IBM/sarama#Config) can be configured under the `kafka.sarama` key. See the following examples section to see advanced configurations.
+
+### Examples
+
+#### Topic monitoring selection
+
+The maximum number of topics to monitor is defined by the key `kafka.topics.max` and by default,  it will monitor the first max number of topics that match the filter rules (in no particular order), the rest will be ignored.
+
+To configure what topics are selected you can use the key `kafka.topics.filter.allow` or the key `kafka.topics.filter.deny`, using both options at the same time is not supported. The value should follow regex RE2 syntax as described in [here](https://github.com/google/re2/wiki/Syntax). For example, to only monitor `topic1` and `topic2` topics:
+
+| Config file YAML key              | Env var                            | Value               |
+|-----------------------------------|------------------------------------|---------------------|
+| `kafka.topics.filter.allow`       | `KAFKA_TOPICS_FILTER_ALLOW`        | `^(topic1|topic2)$` |
+
+Or to monitor all topics but `topic3`:
+
+| Config file YAML key              | Env var                            | Value               |
+|-----------------------------------|------------------------------------|---------------------|
+| `kafka.topics.filter.deny`        | `KAFKA_TOPICS_FILTER_DENY`         | `^topic3$` |
+
+Take into account that `kafka-sampler` automatically discovers new topics so if the configuration is not too restrictive it will automatically monitor new topics as they are created. 
+
+#### Apache Kafka authentication
+
+Kafka supports many authentication methods, since its configuration is not straightforward you can use these examples to get started:
+
+##### SASL/PLAIN
+
+| Config file YAML key              | Env var                            | Value       |
+|-----------------------------------|------------------------------------|-------------|
+| `kafka.sarama.net.sasl.enable`    | `KAFKA_SARAMA_NET_SASL_ENABLE`     | `true`      |
+| `kafka.sarama.net.sasl.user`      | `KAFKA_SARAMA_NET_SASL_USER`       | `<username>`|
+| `kafka.sarama.net.sasl.password`  | `KAFKA_SARAMA_NET_SASL_PASSWORD`   | `<password>`|
+
+##### SASL/SCRAM
+
+| Config file YAML key              | Env var                            | Value                               |
+|-----------------------------------|------------------------------------|-------------------------------------|
+| `kafka.sarama.net.sasl.enable`    | `KAFKA_SARAMA_NET_SASL_ENABLE`     | `true`                              |
+| `kafka.sarama.net.sasl.mechanism` | `KAFKA_SARAMA_NET_SASL_MECHANISM`  | `SCRAM-SHA-256` or `SCRAM-SHA-512`  |
+| `kafka.sarama.net.sasl.user`      | `KAFKA_SARAMA_NET_SASL_USER`       | `<username>`                        |
+| `kafka.sarama.net.sasl.password`  | `KAFKA_SARAMA_NET_SASL_PASSWORD`   | `<password>`                        |
+
+
 <!--ref-end-->
 
 <!-- Link to reference configuration. In the documentation, this file is directly embedded in the reference section -->

--- a/cmd/kafka-sampler/config.go
+++ b/cmd/kafka-sampler/config.go
@@ -24,3 +24,7 @@ func NewConfig() *Config {
 		Neblic: *neblic.NewConfig(),
 	}
 }
+
+func (c *Config) Finalize() error {
+	return c.Kafka.Finalize()
+}

--- a/cmd/kafka-sampler/go.mod
+++ b/cmd/kafka-sampler/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/neblic/platform v0.0.0
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
+	github.com/xdg-go/scram v1.1.2
 	go.uber.org/zap v1.26.0
 	golang.org/x/text v0.14.0
 )
@@ -66,6 +67,8 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.90.1 // indirect
 	go.opentelemetry.io/collector/component v0.90.1 // indirect

--- a/cmd/kafka-sampler/go.sum
+++ b/cmd/kafka-sampler/go.sum
@@ -204,6 +204,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
+github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
+github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=
+github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/cmd/kafka-sampler/kafka/config.go
+++ b/cmd/kafka-sampler/kafka/config.go
@@ -32,3 +32,7 @@ func NewConfig() *Config {
 		},
 	}
 }
+
+func (c *Config) Finalize() error {
+	return sarama.Finalize(&c.Sarama)
+}

--- a/cmd/kafka-sampler/kafka/sarama/config.go
+++ b/cmd/kafka-sampler/kafka/sarama/config.go
@@ -1,6 +1,11 @@
 package sarama
 
-import "github.com/IBM/sarama"
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/IBM/sarama"
+)
 
 type Config = sarama.Config
 
@@ -13,4 +18,19 @@ func NewConfig() *Config {
 	c.ClientID = "neblic-kafka-sampler"
 
 	return c
+}
+
+func Finalize(c *Config) error {
+	if c.Net.SASL.Mechanism == sarama.SASLTypeSCRAMSHA256 {
+		c.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+			return &XDGSCRAMClient{HashGeneratorFcn: sha256.New}
+		}
+	}
+	if c.Net.SASL.Mechanism == sarama.SASLTypeSCRAMSHA512 {
+		c.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+			return &XDGSCRAMClient{HashGeneratorFcn: sha512.New}
+		}
+	}
+
+	return c.Validate()
 }

--- a/cmd/kafka-sampler/kafka/sarama/scram_client.go
+++ b/cmd/kafka-sampler/kafka/sarama/scram_client.go
@@ -1,0 +1,29 @@
+package sarama
+
+import (
+	"github.com/xdg-go/scram"
+)
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/cmd/kafka-sampler/main.go
+++ b/cmd/kafka-sampler/main.go
@@ -115,6 +115,11 @@ func initConfig(path *string) *Config {
 		log.Fatalf("Error unmarshaling config: %v", err)
 	}
 
+	// Finalize configuration
+	if err := config.Finalize(); err != nil {
+		log.Fatalf("Error finalizing config: %v", err)
+	}
+
 	// We need to recreate the metric registry, otherwise it is not properly initilized and segfaults
 	config.Kafka.Sarama.MetricRegistry = sarama.NewConfig().MetricRegistry
 

--- a/dist/kafka-sampler/config.yaml
+++ b/dist/kafka-sampler/config.yaml
@@ -9,8 +9,8 @@ kafka:
   # consumergroup: neblic-kafka-sampler
 
   # Kafka configuration as defined in the Sarama library
-  # https://pkg.go.dev/github.com/shopify/sarama#Config
-  # Convert field names to all lowercase and divide nested structs with `_`
+  # https://pkg.go.dev/github.com/IBM/sarama#Config
+  # Convert field names to all lowercase and nested structs to nested fields
   # sarama:  (...)
 
   # topics:
@@ -25,8 +25,8 @@ kafka:
   #   # supports regex RE2 syntax as described at https://github.com/google/re2/wiki/Syntax, except for `\C`.
   #   # It always ignores internal topics like: `__consumer_offsets` and `__transaction_state`.
   #   filter:
-  #     # Topics matching `allowlist` will be monitored, and topics matching `denylist` will be ignored.
-  #     # `allowlist` and `denylist` can't be set at the same time.
+  #     # Topics matching `allow` will be monitored, and topics matching `deny` will be ignored.
+  #     # `allow` and `deny` options can't be set at the same time.
   #     allow: ^(topic1|topic2)$
   #     deny: ^topic3$
 

--- a/docs/content/reference/kafka-sampler.md
+++ b/docs/content/reference/kafka-sampler.md
@@ -6,6 +6,8 @@
    end="<!--ref-end-->"
 %}
 
+## Default configuration
+
 ``` yaml
 --8<-- "./dist/kafka-sampler/config.yaml"
 ```


### PR DESCRIPTION
## Describe your changes
Support SASL/SCRAM authentication method when connecting to kafka. SCRAM client is automatically injected when SCRAM configuration is detected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
