### PR TITLE
feat(dataplane): implement stateful checks

### DIFF
--- a/docs/content/reference/rules.md
+++ b/docs/content/reference/rules.md
@@ -1,14 +1,29 @@
 # Rules
 
-`Rules` are defined using [Google Common Expression Language (CEL)](https://github.com/google/cel-spec). The language syntax is defined [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax). And you can find a list of definitions (operators, functions, and constants) [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions) (some functions and complex operators may not be supported).
+`Rules` are defined using [Google Common Expression Language (CEL)](https://github.com/google/cel-spec). The language syntax is defined [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax) and the the list of supported operators and functions is defined in [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions) (some functions and complex operators may not be supported). 
 
-The `Data Sample` contents are available under the `sample` key scope. This page provides some examples to get you started:
+Aditionally, Neblic defines some additional functions that can be used when defining streams or checks (not all functions are supported when creating streams).
 
-| CEL expression                                 | Description |
-|------------------------------------------------|-------------|
-| `true`                                         | Matches all `Data Samples`. Useful when creating `Streams` and you just want to select all `Data Samples` |
-| `sample.id != ""`                              | True if the field `id` is defined |
-| `sample.id == "some_id" && sample.val == 1`    | You can use boolean expression like `&&` or `||` to concatenate expressions |
-| `sample.val1 > 0`                              | Numeric values can be compared |
-| `sample.val1 * sample.val2 > 10`               | Arithmetic operations are supported |
-| (`sample.val1 || sample.val2) && sample.val3`  | Use parenthesis to specify operator precedence |
+!!! note
+
+    The `Data Sample` contents are available under the `sample` key scope. This page provides some examples to get you started:
+
+| Neblic defined function  | Description                                                                                                                                                                                                                          | Context             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `abs(<v>)`               | Returns the absolut value of `v`. The input can be a double, or an int                                                                                                                                                               | `streams`, `checks` |
+| `now()`                  | Returns current time in the collector as a timestamp                                                                                                                                                                                 | `streams`, `checks` |
+| `sequence(<v>, <order>)` | Returns true or false depending on if `v` is part of a ordered sequence or not. `order` can be `asc` or `desc`                                                                                                                       | `checks`            |
+| `complete(<v>, <step>)`  | Returns ture or false depening of in `v` is part of a complete sequence or not. A sequence is complete if all the values are ordered and there is no missing value. `step` contains the distance between each two consecutive values | `checks`            |
+
+## Examples
+
+| CEL expression                                  | Description                                                                                               |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `true`                                          | Matches all `Data Samples`. Useful when creating `Streams` and you just want to select all `Data Samples` |
+| `sample.id != ""`                               | True if the field `id` is defined                                                                         |
+| `sample.id == "some_id" && sample.val == 1`     | You can use boolean expression like `&&` or `\|\|` to concatenate expressions                             |
+| `sample.val1 > 0`                               | Numeric values can be compared                                                                            |
+| `sample.val1 * sample.val2 > 10`                | Arithmetic operations are supported                                                                       |
+| `(sample.val1 \|\| sample.val2) && sample.val3` | Use parenthesis to specify operator precedence                                                            |
+| `!sequence(sample.time, "asc")`                 | Matches all the values that are not part of the sequence                                                  |
+| `!complete(sample.time, "asc")`                 | Matches all the values that are not part of a complete sequence                                           |

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/golang/glog v1.1.2
 	github.com/golang/protobuf v1.5.3
 	github.com/google/cel-go v0.18.2
 	github.com/google/renameio/v2 v2.0.0
@@ -31,6 +32,8 @@ require (
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/time v0.5.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20231127180814-3a041ad873d4
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -40,6 +43,7 @@ require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.4-0.20230617002413-005d2dfb6b68 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/bits-and-blooms/bloom v2.0.3+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
@@ -65,7 +69,9 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/willf/bitset v1.1.11 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.90.1 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.90.1 // indirect
@@ -84,8 +90,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.16.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20231127180814-3a041ad873d4 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4 // indirect
 )
 
 exclude github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc h1:Keo7wQ7UODU
 github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc/go.mod h1:k08r+Yj1PRAmuayFiRK6MYuR5Ve4IuZtTfxErMIh0+c=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bloom v2.0.3+incompatible h1:3ONZFjJoMyfHDil5iCcNkcPJ//PNNo+55RHvPrfUGnY=
+github.com/bits-and-blooms/bloom v2.0.3+incompatible/go.mod h1:nEmPH2pqJb3sCXfd7cyDSKC4iPfCAt312JHgNrtnnDE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -54,6 +56,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
+github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -147,6 +151,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -159,6 +165,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
+github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/pkg/rule/builder_cel.go
+++ b/internal/pkg/rule/builder_cel.go
@@ -1,0 +1,155 @@
+package rule
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+type StatefulFunction interface {
+	GetName() string
+	Enabled() bool
+	ParseCallExpression(callExpression *expr.Expr_Call) error
+	GetCelEnvs(stateProvider *StateProvider) []cel.EnvOption
+}
+
+func getStepFromExpression(expression *expr.Expr) (float64, error) {
+	constExpr, ok := expression.ExprKind.(*expr.Expr_ConstExpr)
+	if !ok {
+		return 0, fmt.Errorf("complete function second argument requires a constant float")
+	}
+
+	var step float64
+	switch v := constExpr.ConstExpr.ConstantKind.(type) {
+	case *expr.Constant_Int64Value:
+		step = float64(v.Int64Value)
+	case *expr.Constant_DoubleValue:
+		step = v.DoubleValue
+	default:
+		return 0, fmt.Errorf("complete function second argument requires a constant float or int")
+	}
+
+	return step, nil
+}
+
+func getOrderFromExpression(expression *expr.Expr) (OrderType, error) {
+	constExpr, ok := expression.ExprKind.(*expr.Expr_ConstExpr)
+	if !ok {
+		return OrderTypeUnknown, fmt.Errorf("sequence function second argument requires a constant string with value 'asc' or 'desc'")
+	}
+
+	stringExpr, ok := constExpr.ConstExpr.ConstantKind.(*expr.Constant_StringValue)
+	if !ok {
+		return OrderTypeUnknown, fmt.Errorf("sequence function second argument requires a constant string with value 'asc' or 'desc'")
+	}
+
+	var order OrderType
+	switch stringExpr.StringValue {
+	case "asc":
+		order = OrderTypeAsc
+	case "desc":
+		order = OrderTypeDesc
+	default:
+		return OrderTypeUnknown, fmt.Errorf("sequence function second argument requires a constant string with value 'asc' or 'desc'")
+	}
+
+	return order, nil
+}
+
+func ParseStatefulFunctions(statefulFunctions []StatefulFunction, expression *expr.Expr) error {
+	if expression == nil {
+		return nil
+	}
+
+	switch expression.ExprKind.(type) {
+	case *expr.Expr_SelectExpr:
+		selectExpr := expression.GetSelectExpr()
+
+		// Recursive check of the operand
+		err := ParseStatefulFunctions(statefulFunctions, selectExpr.Operand)
+		if err != nil {
+			return err
+		}
+
+	case *expr.Expr_CallExpr:
+		callExpr := expression.GetCallExpr()
+
+		// Check if function name matches any of the stateful functions
+		for _, statefulFunction := range statefulFunctions {
+			if statefulFunction.GetName() == callExpr.Function {
+				err := statefulFunction.ParseCallExpression(callExpr)
+				if err != nil {
+					return err
+				}
+				break
+			}
+		}
+
+		// Recursive check of the target
+		err := ParseStatefulFunctions(statefulFunctions, callExpr.Target)
+		if err != nil {
+			return err
+		}
+		// Recursive check of the arguments
+		for _, arg := range callExpr.Args {
+			err := ParseStatefulFunctions(statefulFunctions, arg)
+			if err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_ListExpr:
+		listExpr := expression.GetListExpr()
+
+		// Recursive check of the elements
+		for _, element := range listExpr.Elements {
+			err := ParseStatefulFunctions(statefulFunctions, element)
+			if err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_StructExpr:
+		structExpr := expression.GetStructExpr()
+
+		// Recursive check of the entries
+		for _, entry := range structExpr.Entries {
+			err := ParseStatefulFunctions(statefulFunctions, entry.Value)
+			if err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_ComprehensionExpr:
+		comprehensionExpr := expression.GetComprehensionExpr()
+
+		// Recursive check of the itereration range
+		err := ParseStatefulFunctions(statefulFunctions, comprehensionExpr.IterRange)
+		if err != nil {
+			return err
+		}
+		// Recursive check of the accumulator initialization
+		err = ParseStatefulFunctions(statefulFunctions, comprehensionExpr.AccuInit)
+		if err != nil {
+			return err
+		}
+		// Recursive check of the loop condition
+		err = ParseStatefulFunctions(statefulFunctions, comprehensionExpr.LoopCondition)
+		if err != nil {
+			return err
+		}
+		// Recursive check of the loop step
+		err = ParseStatefulFunctions(statefulFunctions, comprehensionExpr.LoopStep)
+		if err != nil {
+			return err
+		}
+		// Recursive check of the result
+		err = ParseStatefulFunctions(statefulFunctions, comprehensionExpr.Result)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/rule/builder_cel_test.go
+++ b/internal/pkg/rule/builder_cel_test.go
@@ -1,0 +1,196 @@
+package rule
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/neblic/platform/sampler/defs"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+func compileExpression(t *testing.T, expression string) *expr.Expr {
+	env, err := cel.NewEnv(CheckFunctionsEnvOptions...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ast, iss := env.Compile(expression)
+	if iss != nil && iss.Err() != nil {
+		t.Fatal(iss.Err())
+	}
+
+	expr, err := cel.AstToCheckedExpr(ast)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return expr.Expr
+}
+
+func Test_ParseStatefulFunctions(t *testing.T) {
+	type args struct {
+		statefulFunctions []StatefulFunction
+		expr              *expr.Expr
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []StatefulFunction
+		wantErr bool
+	}{
+		{
+			name: "sequence function with string field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `sequence("foo", "asc")`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{enabled: true, Order: OrderTypeAsc}, &CompleteStatefulFunction{}},
+			wantErr: false,
+		},
+		{
+			name: "sequence function with int field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `sequence(1, "asc")`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{enabled: true, Order: OrderTypeAsc}, &CompleteStatefulFunction{}},
+			wantErr: false,
+		},
+		{
+			name: "sequence function with uint field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `sequence(1u, "asc")`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{enabled: true, Order: OrderTypeAsc}, &CompleteStatefulFunction{}},
+			wantErr: false,
+		},
+		{
+			name: "sequence function with float field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `sequence(1.0, "asc")`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{enabled: true, Order: OrderTypeAsc}, &CompleteStatefulFunction{}},
+			wantErr: false,
+		},
+		{
+			name: "complete function with int field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `complete(1, 1)`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{enabled: true, Step: 1}},
+			wantErr: false,
+		},
+		{
+			name: "complete function with uint field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `complete(1u, 1)`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{enabled: true, Step: 1}},
+			wantErr: false,
+		},
+		{
+			name: "sequence function with float field",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `complete(1.0, 1.0)`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{enabled: true, Step: 1}},
+			wantErr: false,
+		},
+		{
+			name: "stateful function not in the root of the expression",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `sequence("foo", "asc") && "bar" == "bar"`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{enabled: true, Order: OrderTypeAsc}, &CompleteStatefulFunction{}},
+			wantErr: false,
+		},
+		{
+			name: "multiple stateful functions returns error",
+			args: args{
+				statefulFunctions: []StatefulFunction{&SequenceStatefulFunction{}, &CompleteStatefulFunction{}},
+				expr:              compileExpression(t, `sequence("foo", "asc") && sequence("bar", "asc")`),
+			},
+			want:    []StatefulFunction{&SequenceStatefulFunction{enabled: true, Order: OrderTypeAsc}, &CompleteStatefulFunction{}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ParseStatefulFunctions(tt.args.statefulFunctions, tt.args.expr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Builder.Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(tt.args.statefulFunctions, tt.want) {
+				t.Errorf("ParseStatefulFunctions() = %v, want %v", tt.args.statefulFunctions, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuilder_Build(t *testing.T) {
+	type fields struct {
+		schema defs.Schema
+	}
+	type args struct {
+		rule string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "build rule with abs function",
+			fields: fields{
+				schema: defs.NewDynamicSchema(),
+			},
+			args: args{
+				rule: `abs(-1) == 1`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "build rule with sequence function",
+			fields: fields{
+				schema: defs.NewDynamicSchema(),
+			},
+			args: args{
+				rule: `sequence(-1, "asc")`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "build rule with complete function",
+			fields: fields{
+				schema: defs.NewDynamicSchema(),
+			},
+			args: args{
+				rule: `complete(0, 1)`,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb, err := NewBuilder(tt.fields.schema, CheckFunctions)
+			if err != nil {
+				t.Errorf("Builder.NewBuilder() error = %v", err)
+				return
+			}
+			_, err = rb.Build(tt.args.rule)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Builder.Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/internal/pkg/rule/functions.go
+++ b/internal/pkg/rule/functions.go
@@ -1,21 +1,43 @@
 package rule
 
 import (
+	"fmt"
 	"math"
 	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
-// CelFunctions contains all the custom functions used in the rules
-var CelFunctions = []cel.EnvOption{
-	// aba
+// StreamFunctionsEnvOptions contains all the custom functions used when defining stream rules.
+var StreamFunctionsEnvOptions = []cel.EnvOption{
+	// abs
 	absDoubleFunc,
 	absIntFunc,
 	// now
 	nowFunc,
+}
+
+// CheckFunctionsEnvOptions contains all the custom functions used when defining check rules.
+// Stateful functions added here are dummy functions that are overloaded on-demand with a
+// correctly initialized state when a rule is created.
+var CheckFunctionsEnvOptions = []cel.EnvOption{
+	// abs
+	absDoubleFunc,
+	absIntFunc,
+	// now
+	nowFunc,
+	// sequence (dummy)
+	makeSequenceInt(nil),
+	makeSequenceUint(nil),
+	makeSequenceFloat64(nil),
+	makeSequenceString(nil),
+	// complete (dummy)
+	makeCompleteInt(nil),
+	makeCompleteUint(nil),
+	makeCompleteFloat64(nil),
 }
 
 // abs
@@ -52,3 +74,193 @@ var nowFunc = cel.Function("now",
 		}),
 	),
 )
+
+// sequence (stateful)
+type SequenceStateProvider interface {
+	SequenceAddInt64(int64) bool
+	SequenceAddUint64(uint64) bool
+	SequenceAddFloat64(float64) bool
+	SequenceAddString(string) bool
+}
+
+func makeSequenceInt(stateProvider SequenceStateProvider) cel.EnvOption {
+	return cel.Function("sequence",
+		cel.Overload("sequence_int_string",
+			[]*cel.Type{cel.IntType, cel.StringType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(int64)
+
+				ok := stateProvider.SequenceAddInt64(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+func makeSequenceUint(stateProvider SequenceStateProvider) cel.EnvOption {
+	return cel.Function("sequence",
+		cel.Overload("sequence_uint_string",
+			[]*cel.Type{cel.UintType, cel.StringType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(uint64)
+
+				ok := stateProvider.SequenceAddUint64(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+func makeSequenceFloat64(stateProvider SequenceStateProvider) cel.EnvOption {
+	return cel.Function("sequence",
+		cel.Overload("sequence_double_string",
+			[]*cel.Type{cel.DoubleType, cel.StringType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(float64)
+
+				ok := stateProvider.SequenceAddFloat64(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+func makeSequenceString(stateProvider SequenceStateProvider) cel.EnvOption {
+	return cel.Function("sequence",
+		cel.Overload("sequence_string_string",
+			[]*cel.Type{cel.StringType, cel.StringType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(string)
+
+				ok := stateProvider.SequenceAddString(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+
+type SequenceStatefulFunction struct {
+	enabled bool
+	Order   OrderType
+}
+
+func (ssf *SequenceStatefulFunction) GetName() string {
+	return "sequence"
+}
+
+func (ssf *SequenceStatefulFunction) Enabled() bool {
+	return ssf.enabled
+}
+
+func (ssf *SequenceStatefulFunction) ParseCallExpression(callExpression *expr.Expr_Call) error {
+	if ssf.enabled {
+		return fmt.Errorf("expression already contains a sequence function. Having multiple stateful functions of the same type is not supported")
+	}
+	ssf.enabled = true
+
+	var err error
+	ssf.Order, err = getOrderFromExpression(callExpression.Args[1])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ssf *SequenceStatefulFunction) GetCelEnvs(stateProvider *StateProvider) []cel.EnvOption {
+	stateProvider.WithSequenceState(ssf.Order)
+	return []cel.EnvOption{
+		makeSequenceInt(stateProvider),
+		makeSequenceUint(stateProvider),
+		makeSequenceFloat64(stateProvider),
+		makeSequenceString(stateProvider),
+	}
+}
+
+// complete (stateful)
+type CompleteStateProvider interface {
+	CompleteAddInt64(int64) bool
+	CompleteAddUint64(uint64) bool
+	CompleteAddFloat64(float64) bool
+}
+
+func makeCompleteInt(stateProvider CompleteStateProvider) cel.EnvOption {
+	return cel.Function("complete",
+		cel.Overload("complete_int_int",
+			[]*cel.Type{cel.IntType, cel.IntType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(int64)
+
+				ok := stateProvider.CompleteAddInt64(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+func makeCompleteUint(stateProvider CompleteStateProvider) cel.EnvOption {
+	return cel.Function("complete",
+		cel.Overload("complete_uint_int",
+			[]*cel.Type{cel.UintType, cel.IntType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(uint64)
+
+				ok := stateProvider.CompleteAddUint64(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+func makeCompleteFloat64(stateProvider CompleteStateProvider) cel.EnvOption {
+	return cel.Function("complete",
+		cel.Overload("complete_double_double",
+			[]*cel.Type{cel.DoubleType, cel.DoubleType},
+			cel.BoolType,
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				value := args[0].Value().(float64)
+
+				ok := stateProvider.CompleteAddFloat64(value)
+				return types.Bool(ok)
+			}),
+		),
+	)
+}
+
+type CompleteStatefulFunction struct {
+	enabled bool
+	Step    float64
+}
+
+func (csf *CompleteStatefulFunction) GetName() string {
+	return "complete"
+}
+
+func (csf *CompleteStatefulFunction) Enabled() bool {
+	return csf.enabled
+}
+
+func (csf *CompleteStatefulFunction) ParseCallExpression(callExpression *expr.Expr_Call) error {
+	if csf.enabled {
+		return fmt.Errorf("expression already contains a complete function. Having multiple stateful functions of the same type is not supported")
+	}
+	csf.enabled = true
+
+	var err error
+	csf.Step, err = getStepFromExpression(callExpression.Args[1])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (csf *CompleteStatefulFunction) GetCelEnvs(stateProvider *StateProvider) []cel.EnvOption {
+	stateProvider.WithCompleteState(csf.Step)
+	return []cel.EnvOption{
+		makeCompleteInt(stateProvider),
+		makeCompleteUint(stateProvider),
+		makeCompleteFloat64(stateProvider),
+	}
+}

--- a/internal/pkg/rule/functions_test.go
+++ b/internal/pkg/rule/functions_test.go
@@ -63,6 +63,93 @@ func TestFunctions(t *testing.T) {
 			},
 			want: types.Int(time.Now().YearDay()),
 		},
+
+		// sequence
+		{
+			name: "sequence with int and string order",
+			celEnvOpts: celEnvOpts{
+				function:  makeSequenceInt(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `sequence(1, "asc")`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
+		{
+			name: "sequence with uint and string order",
+			celEnvOpts: celEnvOpts{
+				function:  makeSequenceUint(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `sequence(1u, "asc")`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
+		{
+			name: "sequence with double and string order",
+			celEnvOpts: celEnvOpts{
+				function:  makeSequenceFloat64(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `sequence(1.0, "asc")`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
+		{
+			name: "sequence with string and string order",
+			celEnvOpts: celEnvOpts{
+				function:  makeSequenceString(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `sequence("1", "asc")`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
+		// complete
+		{
+			name: "complete with int and int step",
+			celEnvOpts: celEnvOpts{
+				function:  makeCompleteInt(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `complete(1, 1)`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
+		{
+			name: "complete with uint and int step",
+			celEnvOpts: celEnvOpts{
+				function:  makeCompleteUint(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `complete(1u, 1)`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
+		{
+			name: "complete with double, double step",
+			celEnvOpts: celEnvOpts{
+				function:  makeCompleteFloat64(NewStateProvider()),
+				variables: []cel.EnvOption{},
+			},
+			args: args{
+				expression: `complete(1.0, 1.0)`,
+				variables:  map[string]any{},
+			},
+			want: types.Bool(true),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pkg/rule/rule.go
+++ b/internal/pkg/rule/rule.go
@@ -18,15 +18,17 @@ const (
 )
 
 type Rule struct {
-	schema     defs.Schema
-	prg        cel.Program
-	sampleComp sampleCompatibility
+	schema        defs.Schema
+	prg           cel.Program
+	sampleComp    sampleCompatibility
+	stateProvider *StateProvider
 }
 
-func New(schema defs.Schema, prg cel.Program) *Rule {
+func New(schema defs.Schema, prg cel.Program, stateProvider *StateProvider) *Rule {
 	r := &Rule{
-		schema: schema,
-		prg:    prg,
+		schema:        schema,
+		prg:           prg,
+		stateProvider: stateProvider,
 	}
 	r.setCompatibility(schema)
 
@@ -92,4 +94,8 @@ func (r *Rule) Eval(ctx context.Context, sampleData *data.Data) (bool, error) {
 
 	// It is guaranteed to be a boolean because the rule has been checked at build time
 	return val.Value().(bool), nil
+}
+
+func (r *Rule) StateProvider() *StateProvider {
+	return r.stateProvider
 }

--- a/internal/pkg/rule/state.go
+++ b/internal/pkg/rule/state.go
@@ -1,0 +1,170 @@
+package rule
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+type OrderType int8
+
+const (
+	OrderTypeUnknown OrderType = iota
+	OrderTypeNone
+	OrderTypeAsc
+	OrderTypeDesc
+)
+
+// SequenceState
+type SequenceState[T constraints.Ordered] struct {
+	last          *T
+	expectedOrder OrderType
+	Order         OrderType
+}
+
+func NewSequenceState[T constraints.Ordered](orderType OrderType) *SequenceState[T] {
+	return &SequenceState[T]{
+		expectedOrder: orderType,
+		Order:         orderType,
+	}
+}
+
+func (ss *SequenceState[T]) Add(value T) bool {
+	if ss.last == nil {
+		ss.last = &value
+		return true
+	}
+
+	isOrdered := true
+	switch ss.expectedOrder {
+	case OrderTypeAsc:
+		if value < *ss.last {
+			isOrdered = false
+			ss.Order = OrderTypeNone
+		}
+	case OrderTypeDesc:
+		if value > *ss.last {
+			isOrdered = false
+			ss.Order = OrderTypeNone
+		}
+	}
+
+	ss.last = &value
+
+	return isOrdered
+}
+
+// CompleteState
+type Number interface {
+	constraints.Float | constraints.Integer
+}
+
+type CompleteState[T Number] struct {
+	next        *T
+	step        T
+	AllComplete bool
+}
+
+func NewCompleteState[T Number](step T) *CompleteState[T] {
+	return &CompleteState[T]{
+		step:        step,
+		AllComplete: true,
+	}
+}
+
+func (ss *CompleteState[T]) Add(value T) bool {
+	if ss.next == nil {
+		ss.next = &value
+		return true
+	}
+
+	isComplete := value == *ss.next
+	if !isComplete {
+		ss.AllComplete = false
+	}
+
+	*ss.next = value + ss.step
+
+	return isComplete
+}
+
+// StateProvider
+type StateProvider struct {
+	// Sequence state
+	SequenceEnabled bool
+	sequenceOrder   OrderType
+	sequenceInt64   *SequenceState[int64]
+	sequenceUint64  *SequenceState[uint64]
+	sequenceFloat64 *SequenceState[float64]
+	sequenceString  *SequenceState[string]
+
+	// Complete state
+	CompleteEnabled bool
+	completeStep    float64
+	completeInt64   *CompleteState[int64]
+	completeUint64  *CompleteState[uint64]
+	completeFloat64 *CompleteState[float64]
+}
+
+func NewStateProvider() *StateProvider {
+	return &StateProvider{}
+}
+
+func (sp *StateProvider) WithSequenceState(order OrderType) *StateProvider {
+	sp.SequenceEnabled = true
+	sp.sequenceOrder = order
+	return sp
+}
+
+func (sp *StateProvider) WithCompleteState(step float64) *StateProvider {
+	sp.CompleteEnabled = true
+	sp.completeStep = step
+	return sp
+}
+
+func (sp *StateProvider) SequenceAddInt64(v int64) bool {
+	if sp.sequenceInt64 == nil {
+		sp.sequenceInt64 = NewSequenceState[int64](sp.sequenceOrder)
+	}
+	return sp.sequenceInt64.Add(v)
+}
+
+func (sp *StateProvider) SequenceAddUint64(v uint64) bool {
+	if sp.sequenceUint64 == nil {
+		sp.sequenceUint64 = NewSequenceState[uint64](sp.sequenceOrder)
+	}
+	return sp.sequenceUint64.Add(v)
+}
+
+func (sp *StateProvider) SequenceAddFloat64(v float64) bool {
+	if sp.sequenceFloat64 == nil {
+		sp.sequenceFloat64 = NewSequenceState[float64](sp.sequenceOrder)
+	}
+	return sp.sequenceFloat64.Add(v)
+}
+
+func (sp *StateProvider) SequenceAddString(v string) bool {
+	if sp.sequenceString == nil {
+		sp.sequenceString = NewSequenceState[string](sp.sequenceOrder)
+	}
+	return sp.sequenceString.Add(v)
+}
+
+func (sp *StateProvider) CompleteAddInt64(v int64) bool {
+	if sp.completeInt64 == nil {
+		sp.completeInt64 = NewCompleteState[int64](int64(sp.completeStep))
+	}
+	return sp.completeInt64.Add(v)
+}
+
+func (sp *StateProvider) CompleteAddUint64(v uint64) bool {
+	if sp.completeUint64 == nil {
+		sp.completeUint64 = NewCompleteState[uint64](uint64(sp.completeStep))
+	}
+	return sp.completeUint64.Add(v)
+}
+
+func (sp *StateProvider) CompleteAddFloat64(v float64) bool {
+	if sp.completeFloat64 == nil {
+		sp.completeFloat64 = NewCompleteState[float64](sp.completeStep)
+	}
+	return sp.completeFloat64.Add(v)
+}

--- a/internal/pkg/rule/state_test.go
+++ b/internal/pkg/rule/state_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestSequenceState_Add(t *testing.T) {
-	var zeroInt64 int64 = 0
-	var zeroUint64 uint64 = 0
-	var float64Zero float64 = 0
-	var stringZero string = "0"
+	zeroInt64 := int64(0)
+	zeroUint64 := uint64(0)
+	float64Zero := float64(0)
+	stringZero := "0"
 
 	type fields[T constraints.Ordered] struct {
 		last          *T
@@ -192,7 +192,7 @@ func TestSequenceState_Add(t *testing.T) {
 }
 
 func TestCompleteState_Add(t *testing.T) {
-	var oneInt64 int64 = 1
+	oneInt64 := int64(1)
 
 	type fields[T constraints.Ordered] struct {
 		next        *T

--- a/internal/pkg/rule/state_test.go
+++ b/internal/pkg/rule/state_test.go
@@ -1,0 +1,283 @@
+package rule
+
+import (
+	"testing"
+
+	"golang.org/x/exp/constraints"
+)
+
+func TestSequenceState_Add(t *testing.T) {
+	var zeroInt64 int64 = 0
+	var zeroUint64 uint64 = 0
+	var float64Zero float64 = 0
+	var stringZero string = "0"
+
+	type fields[T constraints.Ordered] struct {
+		last          *T
+		expectedOrder OrderType
+		Order         OrderType
+	}
+	type args[T constraints.Ordered] struct {
+		value T
+	}
+	tests := []struct {
+		name   string
+		fields any
+		args   any
+		want   bool
+	}{
+		{
+			name: "add first int64 keeps ascendant order",
+			fields: fields[int64]{
+				last:          nil,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[int64]{
+				value: 0,
+			},
+			want: true,
+		},
+		{
+			name: "add non increasing int64 keeps ascendant order",
+			fields: fields[int64]{
+				last:          &zeroInt64,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[int64]{
+				value: 0,
+			},
+			want: true,
+		},
+		{
+			name: "add increasing int64 keeps ascendant order",
+			fields: fields[int64]{
+				last:          &zeroInt64,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[int64]{
+				value: 1,
+			},
+			want: true,
+		},
+		{
+			name: "add non decreasing int64 violates ascendant order",
+			fields: fields[int64]{
+				last:          &zeroInt64,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[int64]{
+				value: -1,
+			},
+			want: false,
+		},
+		{
+			name: "add non decreasing int64 keeps descendant order",
+			fields: fields[int64]{
+				last:          &zeroInt64,
+				expectedOrder: OrderTypeDesc,
+				Order:         OrderTypeDesc,
+			},
+			args: args[int64]{
+				value: 0,
+			},
+			want: true,
+		},
+		{
+			name: "add decreasing int64 keeps descendant order",
+			fields: fields[int64]{
+				last:          &zeroInt64,
+				expectedOrder: OrderTypeDesc,
+				Order:         OrderTypeDesc,
+			},
+			args: args[int64]{
+				value: -1,
+			},
+			want: true,
+		},
+		{
+			name: "add increasing int64 violates descendant order",
+			fields: fields[int64]{
+				last:          &zeroInt64,
+				expectedOrder: OrderTypeDesc,
+				Order:         OrderTypeDesc,
+			},
+			args: args[int64]{
+				value: 1,
+			},
+			want: false,
+		},
+		{
+			name: "add increasing uint64 keeps ascendant order",
+			fields: fields[uint64]{
+				last:          &zeroUint64,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[uint64]{
+				value: 1,
+			},
+			want: true,
+		},
+		{
+			name: "add increasing float64 keeps ascendant order",
+			fields: fields[float64]{
+				last:          &float64Zero,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[float64]{
+				value: 1,
+			},
+			want: true,
+		},
+		{
+			name: "add increasing string keeps ascendant order",
+			fields: fields[string]{
+				last:          &stringZero,
+				expectedOrder: OrderTypeAsc,
+				Order:         OrderTypeAsc,
+			},
+			args: args[string]{
+				value: "1",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bool
+			switch tt.fields.(type) {
+			case fields[int64]:
+				ss := &SequenceState[int64]{
+					last:          tt.fields.(fields[int64]).last,
+					expectedOrder: tt.fields.(fields[int64]).expectedOrder,
+					Order:         tt.fields.(fields[int64]).Order,
+				}
+				got = ss.Add(tt.args.(args[int64]).value)
+			case fields[uint64]:
+				ss := &SequenceState[uint64]{
+					last:          tt.fields.(fields[uint64]).last,
+					expectedOrder: tt.fields.(fields[uint64]).expectedOrder,
+					Order:         tt.fields.(fields[uint64]).Order,
+				}
+				got = ss.Add(tt.args.(args[uint64]).value)
+			case fields[float64]:
+				ss := &SequenceState[float64]{
+					last:          tt.fields.(fields[float64]).last,
+					expectedOrder: tt.fields.(fields[float64]).expectedOrder,
+					Order:         tt.fields.(fields[float64]).Order,
+				}
+				got = ss.Add(tt.args.(args[float64]).value)
+			case fields[string]:
+				ss := &SequenceState[string]{
+					last:          tt.fields.(fields[string]).last,
+					expectedOrder: tt.fields.(fields[string]).expectedOrder,
+					Order:         tt.fields.(fields[string]).Order,
+				}
+				got = ss.Add(tt.args.(args[string]).value)
+			default:
+				t.Error("unknown type")
+				t.FailNow()
+			}
+
+			if got != tt.want {
+				t.Errorf("SequenceState.Add() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteState_Add(t *testing.T) {
+	var oneInt64 int64 = 1
+
+	type fields[T constraints.Ordered] struct {
+		next        *T
+		step        T
+		AllComplete bool
+	}
+	type args[T constraints.Ordered] struct {
+		value T
+	}
+	tests := []struct {
+		name   string
+		fields any
+		args   any
+		want   bool
+	}{
+		{
+			name: "add first int64 keeps completness",
+			fields: fields[int64]{
+				next:        nil,
+				step:        1,
+				AllComplete: true,
+			},
+			args: args[int64]{
+				value: 0,
+			},
+			want: true,
+		},
+		{
+			name: "add expected value keeps completness",
+			fields: fields[int64]{
+				next:        &oneInt64,
+				step:        1,
+				AllComplete: true,
+			},
+			args: args[int64]{
+				value: 1,
+			},
+			want: true,
+		},
+		{
+			name: "add increasing int64 keeps ascendant order",
+			fields: fields[int64]{
+				next:        &oneInt64,
+				step:        1,
+				AllComplete: true,
+			},
+			args: args[int64]{
+				value: 1000000,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bool
+			switch tt.fields.(type) {
+			case fields[int64]:
+				ss := &CompleteState[int64]{
+					next:        tt.fields.(fields[int64]).next,
+					step:        tt.fields.(fields[int64]).step,
+					AllComplete: tt.fields.(fields[int64]).AllComplete,
+				}
+				got = ss.Add(tt.args.(args[int64]).value)
+			case fields[uint64]:
+				ss := &CompleteState[uint64]{
+					next:        tt.fields.(fields[uint64]).next,
+					step:        tt.fields.(fields[uint64]).step,
+					AllComplete: tt.fields.(fields[uint64]).AllComplete,
+				}
+				got = ss.Add(tt.args.(args[uint64]).value)
+			case fields[float64]:
+				ss := &CompleteState[float64]{
+					next:        tt.fields.(fields[float64]).next,
+					step:        tt.fields.(fields[float64]).step,
+					AllComplete: tt.fields.(fields[float64]).AllComplete,
+				}
+				got = ss.Add(tt.args.(args[float64]).value)
+			default:
+				t.Error("unknown type")
+				t.FailNow()
+			}
+
+			if got != tt.want {
+				t.Errorf("CompleteState.Add() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sampler/internal/sampler/sampler.go
+++ b/sampler/internal/sampler/sampler.go
@@ -49,7 +49,7 @@ func New(
 	settings *Settings,
 	logger logging.Logger,
 ) (*Sampler, error) {
-	ruleBuilder, err := rule.NewBuilder(settings.Schema)
+	ruleBuilder, err := rule.NewBuilder(settings.Schema, rule.StreamFunctions)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't build CEL rule builder: %w", err)
 	}


### PR DESCRIPTION
## Describe your changes
This PR sets the base for the implementation of stateful rules in the context of defining checks. Stateful rules are injected to the CEL environment similarly as stateless ones, the only difference is that a state provider is injected as well. This state provider is the one used to manipulate the state during the execution of the function.

The following stateful functions have been implemented:
- `sequence`
- `complete`

### CEL environment extension
Each CEL expression must use its own state that's totally isolated of the other states. In order to achieve that, each expression using a stateful function has its own CEL environment (state provider is defined when injecting the function overload). As stateless functions don't require that, the extension of the CEL environment is not done in those cases (to avoid allocating unnecessary memory).

### Traversing CEL expressions AST
The CEL expressions AST is traversed to be able to verify at compilation time that the parameters provided by the user are correct and to extract the values in order to correctly initialize the state. At the same time, it's also used to know what stateful functions are used, detect if a function is used more than one (and throw an error), and know when to extend the CEL environment.

### Restrictions
-  Just one instance of each stateful function can be used in a specific CEL expression. When defining the CEL env, just one overload can just be injected once, so we cannot have the same function with multiple states, just one state.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
