### PR TITLE
feat(sample): add WithKeyField option to grpc interceptor to specifify how to get a key from the intercepted proto message

### DIFF
--- a/sampler/instrumentation/google.golang.org/grpc/interceptor_test.go
+++ b/sampler/instrumentation/google.golang.org/grpc/interceptor_test.go
@@ -1,0 +1,38 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/neblic/platform/controlplane/protos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetValueFromProto(t *testing.T) {
+	// any message will do
+	msg := protos.ClientToServer{
+		ClientUid: "uid",
+		Message: &protos.ClientToServer_SamplerConfReq{
+			SamplerConfReq: &protos.ClientSamplerConfReq{
+				SamplerName: "sampler",
+			},
+		},
+	}
+
+	// get a value from a top-level field
+	value := getValueFromProto(&msg, "client_uid")
+	str, ok := value.Interface().(string)
+	require.True(t, ok)
+	assert.Equal(t, "uid", str)
+
+	// get a value from a nested field
+	value = getValueFromProto(&msg, "sampler_conf_req.sampler_name")
+	str, ok = value.Interface().(string)
+	require.True(t, ok)
+	assert.Equal(t, "sampler", str)
+
+	// get a value from a non-existent field
+	value = getValueFromProto(&msg, "non_existent_field")
+	str, ok = value.Interface().(string)
+	require.False(t, ok)
+}


### PR DESCRIPTION
## Describe your changes

We need some way to allow the user to specify how to get a key from the intercepted message. This option is a bit limited since all the intercepted messages must have the key in the same path. A more advanced option would be to allow the user to specify a map of message->path and additional options like a default path and what to do if the key is not found.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
