### PR TITLE
feat(sampler): skip evaluation if expression is always true or false

### DIFF
--- a/dataplane/event/eventor.go
+++ b/dataplane/event/eventor.go
@@ -60,7 +60,7 @@ func (e *Eventor) newEventFrom(eventCfg control.Event, streamsCfg control.Stream
 		return nil, fmt.Errorf("stream %s not found", eventCfg.StreamUID)
 	}
 
-	rule, err := e.ruleBuilder.Build(eventCfg.Rule.Expression, stream)
+	rule, err := e.ruleBuilder.Build(eventCfg.Rule.Expression, stream.Keyed)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule: %w", err)
 	}

--- a/internal/pkg/rule/builder.go
+++ b/internal/pkg/rule/builder.go
@@ -96,7 +96,7 @@ func (rb *Builder) Build(rule string, stream control.Stream) (*Rule, error) {
 	ast = cel.CheckedExprToAst(expr)
 
 	// TODO: Investigate interesting program options: e.g. cost estimation/limit
-	prg, err := env.Program(ast)
+	prg, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
 	if err != nil {
 		return nil, fmt.Errorf("couldn't build CEL program: %w", err)
 	}

--- a/internal/pkg/rule/builder.go
+++ b/internal/pkg/rule/builder.go
@@ -62,7 +62,7 @@ func NewBuilder(schema sample.Schema, supportedFunctions SupportedFunctions) (*B
 	}, nil
 }
 
-func (rb *Builder) Build(rule string, stream control.Stream) (*Rule, error) {
+func (rb *Builder) Build(rule string, keyed control.Keyed) (*Rule, error) {
 	env := rb.env
 
 	ast, iss := env.Compile(rule)
@@ -87,9 +87,9 @@ func (rb *Builder) Build(rule string, stream control.Stream) (*Rule, error) {
 	}
 
 	// Configure managed keyed state if necessary
-	if stream.Keyed.Enabled {
+	if keyed.Enabled {
 		for _, provider := range providers {
-			provider.WithManagedKeyedState(stream.Keyed.TTL, stream.Keyed.MaxKeys)
+			provider.WithManagedKeyedState(keyed.TTL, keyed.MaxKeys)
 		}
 	}
 

--- a/internal/pkg/rule/builder_test.go
+++ b/internal/pkg/rule/builder_test.go
@@ -13,7 +13,7 @@ func TestBuilder_Build(t *testing.T) {
 	}
 	type args struct {
 		rule   string
-		stream control.Stream
+		stream control.Keyed
 	}
 	tests := []struct {
 		name    string
@@ -28,7 +28,7 @@ func TestBuilder_Build(t *testing.T) {
 			},
 			args: args{
 				rule:   `abs(-1) == 1`,
-				stream: control.Stream{},
+				stream: control.Keyed{},
 			},
 			wantErr: false,
 		},
@@ -39,7 +39,7 @@ func TestBuilder_Build(t *testing.T) {
 			},
 			args: args{
 				rule:   `sequence(-1, "asc")`,
-				stream: control.Stream{},
+				stream: control.Keyed{},
 			},
 			wantErr: false,
 		},
@@ -50,7 +50,7 @@ func TestBuilder_Build(t *testing.T) {
 			},
 			args: args{
 				rule:   `complete(0, 1)`,
-				stream: control.Stream{},
+				stream: control.Keyed{},
 			},
 			wantErr: false,
 		},

--- a/internal/pkg/rule/rule.go
+++ b/internal/pkg/rule/rule.go
@@ -23,12 +23,11 @@ type Rule struct {
 	schema     sample.Schema
 	sampleComp sampleCompatibility
 
-	prg        cel.Program
+	prg              cel.Program
 	returnsStaticRes bool
 	staticRes        bool
 
-
-	providers  []*function.StatefulFunctionProvider
+	providers []*function.StatefulFunctionProvider
 }
 
 func New(schema sample.Schema, prg cel.Program, providers []*function.StatefulFunctionProvider) *Rule {

--- a/internal/pkg/rule/rule.go
+++ b/internal/pkg/rule/rule.go
@@ -19,7 +19,6 @@ const (
 )
 
 type Rule struct {
-	ctx        context.Context
 	schema     sample.Schema
 	sampleComp sampleCompatibility
 
@@ -32,7 +31,6 @@ type Rule struct {
 
 func New(schema sample.Schema, prg cel.Program, providers []*function.StatefulFunctionProvider) *Rule {
 	r := &Rule{
-		ctx:       context.Background(),
 		schema:    schema,
 		prg:       prg,
 		providers: providers,

--- a/internal/pkg/rule/rule_test.go
+++ b/internal/pkg/rule/rule_test.go
@@ -50,7 +50,7 @@ func TestEvalJSON(t *testing.T) {
 			rb, err := NewBuilder(sample.DynamicSchema{}, CheckFunctions)
 			require.NoError(t, err)
 
-			rule, err := rb.Build(tc.expression, control.Stream{})
+			rule, err := rb.Build(tc.expression, control.Keyed{})
 			require.NoError(t, err)
 
 			s := data.NewSampleDataFromJSON(tc.sample)
@@ -109,7 +109,7 @@ func TestEvalNative(t *testing.T) {
 			rb, err := NewBuilder(sample.NewDynamicSchema(), CheckFunctions)
 			require.NoError(t, err)
 
-			rule, err := rb.Build(tc.expression, control.Stream{})
+			rule, err := rb.Build(tc.expression, control.Keyed{})
 			require.NoError(t, err)
 
 			s := data.NewSampleDataFromNative(tc.sample)
@@ -153,7 +153,7 @@ func TestEvalProto(t *testing.T) {
 			rb, err := NewBuilder(sample.NewProtoSchema(&protos.SamplerToServer{}), CheckFunctions)
 			require.NoError(t, err)
 
-			rule, err := rb.Build(tc.expression, control.Stream{})
+			rule, err := rb.Build(tc.expression, control.Keyed{})
 			require.NoError(t, err)
 
 			s := data.NewSampleDataFromProto(tc.sample)
@@ -172,7 +172,7 @@ func TestEvalSequence(t *testing.T) {
 	rb, err := NewBuilder(sample.DynamicSchema{}, CheckFunctions)
 	require.NoError(t, err)
 
-	rule, err := rb.Build(`sequence(sample.id, "asc")`, control.Stream{})
+	rule, err := rb.Build(`sequence(sample.id, "asc")`, control.Keyed{})
 	require.NoError(t, err)
 
 	gotMatch, err := rule.Eval(context.Background(), data.NewSampleDataFromJSON(`{"id": 1}`))
@@ -192,7 +192,7 @@ func TestEvalComplete(t *testing.T) {
 	rb, err := NewBuilder(sample.DynamicSchema{}, CheckFunctions)
 	require.NoError(t, err)
 
-	rule, err := rb.Build(`complete(sample.id, 1.0)`, control.Stream{})
+	rule, err := rb.Build(`complete(sample.id, 1.0)`, control.Keyed{})
 	require.NoError(t, err)
 
 	gotMatch, err := rule.Eval(context.Background(), data.NewSampleDataFromJSON(`{"id": 1}`))
@@ -212,7 +212,7 @@ func TestEvalKeyedJSON(t *testing.T) {
 	rb, err := NewBuilder(sample.DynamicSchema{}, CheckFunctions)
 	require.NoError(t, err)
 
-	rule, err := rb.Build(`sequence(sample.id, "asc")`, control.Stream{Keyed: control.Keyed{Enabled: true, MaxKeys: 2}})
+	rule, err := rb.Build(`sequence(sample.id, "asc")`, control.Keyed{Enabled: true, MaxKeys: 2})
 	require.NoError(t, err)
 
 	// key1 first eval is always true
@@ -305,7 +305,7 @@ func TestEvaluateEvalTrue(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			rule, err := rb.Build(tc.rule, control.Stream{})
+			rule, err := rb.Build(tc.rule, control.Keyed{})
 			require.NoError(t, err)
 			require.Equal(t, tc.wantReturnStaticRes, rule.returnsStaticRes)
 			assert.Equal(t, tc.staticRes, rule.staticRes)

--- a/sampler/internal/sampler/sampler.go
+++ b/sampler/internal/sampler/sampler.go
@@ -251,7 +251,7 @@ func (p *Sampler) updateConfig(config control.SamplerConfig) {
 func (p *Sampler) buildSamplingRule(streamRule control.Rule, stream control.Stream) (*rule.Rule, error) {
 	switch streamRule.Lang {
 	case control.SrlCel:
-		builtRule, err := p.ruleBuilder.Build(streamRule.Expression, stream)
+		builtRule, err := p.ruleBuilder.Build(streamRule.Expression, stream.Keyed)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't build CEL rule %s: %s", streamRule.Expression, err)
 		}


### PR DESCRIPTION
## Describe your changes

Check at build time if a rule will always evaluate to true or false. If that is the case, do not parse the sample nor evaluate the CEL rule to avoid unnecessary computations.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
