### PR TITLE
refactor(dataplane): make protocol more opentelemetry friendly

### DIFF
--- a/dataplane/sample/otlplog.go
+++ b/dataplane/sample/otlplog.go
@@ -62,7 +62,7 @@ func OTLPLogToSampleType[T OTLPLog]() control.SampleType {
 }
 
 func getSampleType(logRecord plog.LogRecord) control.SampleType {
-	value, ok := logRecord.Attributes().Get(lrSampleTypeKey)
+	value, ok := logRecord.Attributes().Get(OTLPLogSampleTypeKey)
 	if !ok {
 		return control.UnknownSampleType
 	}
@@ -76,7 +76,7 @@ type baseOTLPLog struct {
 }
 
 func newBaseOTLPLog(logRecord plog.LogRecord, sampleType control.SampleType) baseOTLPLog {
-	logRecord.Attributes().PutStr(lrSampleTypeKey, sampleType.String())
+	logRecord.Attributes().PutStr(OTLPLogSampleTypeKey, sampleType.String())
 
 	return baseOTLPLog{
 		logRecord: logRecord,
@@ -92,7 +92,7 @@ func (b baseOTLPLog) SetTimestamp(ts time.Time) {
 }
 
 func (b baseOTLPLog) StreamsStr() []string {
-	value, ok := b.logRecord.Attributes().Get(lrSampleStreamsUIDsKey)
+	value, ok := b.logRecord.Attributes().Get(OTLPLogStreamsUIDsKey)
 	if !ok {
 		return []string{}
 	}
@@ -106,7 +106,7 @@ func (b baseOTLPLog) StreamsStr() []string {
 }
 
 func (b baseOTLPLog) Streams() []control.SamplerStreamUID {
-	value, ok := b.logRecord.Attributes().Get(lrSampleStreamsUIDsKey)
+	value, ok := b.logRecord.Attributes().Get(OTLPLogStreamsUIDsKey)
 	if !ok {
 		return []control.SamplerStreamUID{}
 	}
@@ -120,7 +120,7 @@ func (b baseOTLPLog) Streams() []control.SamplerStreamUID {
 }
 
 func (b baseOTLPLog) SetStreams(streams []control.SamplerStreamUID) {
-	lrStreamUIDs := b.logRecord.Attributes().PutEmptySlice(lrSampleStreamsUIDsKey)
+	lrStreamUIDs := b.logRecord.Attributes().PutEmptySlice(OTLPLogStreamsUIDsKey)
 	lrStreamUIDs.EnsureCapacity(len(streams))
 	for _, stream := range streams {
 		lrStreamUIDs.AppendEmpty().SetStr(string(stream))
@@ -132,7 +132,7 @@ func (b baseOTLPLog) SampleType() control.SampleType {
 }
 
 func (b baseOTLPLog) SampleKey() string {
-	value, ok := b.logRecord.Attributes().Get(lrSampleKey)
+	value, ok := b.logRecord.Attributes().Get(OTLPLogSampleKey)
 	if !ok {
 		return ""
 	}
@@ -141,11 +141,11 @@ func (b baseOTLPLog) SampleKey() string {
 }
 
 func (b baseOTLPLog) SetSampleKey(key string) {
-	b.logRecord.Attributes().PutStr(lrSampleKey, key)
+	b.logRecord.Attributes().PutStr(OTLPLogSampleKey, key)
 }
 
 func (b baseOTLPLog) SampleEncoding() Encoding {
-	value, ok := b.logRecord.Attributes().Get(lrSampleEncodingKey)
+	value, ok := b.logRecord.Attributes().Get(OTLPLogSampleEncodingKey)
 	if !ok {
 		return UnknownEncoding
 	}
@@ -162,7 +162,7 @@ func (b baseOTLPLog) SampleRawData() []byte {
 }
 
 func (b baseOTLPLog) SetSampleRawData(encoding Encoding, data []byte) {
-	b.logRecord.Attributes().PutStr(lrSampleEncodingKey, encoding.String())
+	b.logRecord.Attributes().PutStr(OTLPLogSampleEncodingKey, encoding.String())
 
 	if encoding == JSONEncoding {
 		b.logRecord.Body().SetStr(string(data))
@@ -369,9 +369,9 @@ func OTLPLogsFrom(plogs plog.Logs) OTLPLogs {
 func (l *OTLPLogs) AppendSamplerOTLPLogs(resource string, sampler string) SamplerOTLPLogs {
 	resourceLogs := l.logs.ResourceLogs().AppendEmpty()
 	resourceLogs.Resource().Attributes().PutStr(conventions.AttributeServiceName, resource)
-	resourceLogs.Resource().Attributes().PutStr(rlSamplerNameKey, sampler)
 
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().SetName(sampler)
 
 	return SamplerOTLPLogs{
 		resourceLogs: resourceLogs,

--- a/dataplane/sample/range.go
+++ b/dataplane/sample/range.go
@@ -11,28 +11,23 @@ func RangeSamplers(otlpLogs OTLPLogs, fn func(resource, sampler string, samplerL
 	for i := 0; i < resourceLogsLen; i++ {
 		rLog := otlpLogs.logs.ResourceLogs().At(i)
 
-		var sampler string
-		if samplerValue, ok := rLog.Resource().Attributes().Get(rlSamplerNameKey); ok {
-			sampler = samplerValue.Str()
-		}
-
 		var resource string
 		if resourceValue, ok := rLog.Resource().Attributes().Get(conventions.AttributeServiceName); ok {
 			resource = resourceValue.Str()
 		}
 
-		if rLog.ScopeLogs().Len() != 1 {
-			panic("expected only one scope log")
+		for j := 0; j < rLog.ScopeLogs().Len(); j++ {
+			sLog := rLog.ScopeLogs().At(j)
+
+			sampler := sLog.Scope().Name()
+
+			samplerLogs := SamplerOTLPLogs{
+				resourceLogs: rLog,
+				scopeLogs:    sLog,
+			}
+
+			fn(resource, sampler, samplerLogs)
 		}
-
-		slogs := rLog.ScopeLogs().At(0)
-
-		samplerLogs := SamplerOTLPLogs{
-			resourceLogs: rLog,
-			scopeLogs:    slogs,
-		}
-
-		fn(resource, sampler, samplerLogs)
 	}
 }
 

--- a/dataplane/sample/sample.go
+++ b/dataplane/sample/sample.go
@@ -7,13 +7,11 @@ import (
 )
 
 const (
-	// resource attributes
-	rlSamplerNameKey = "sampler_name"
 	// sample attributes
-	lrSampleStreamsUIDsKey = "stream_uids"
-	lrSampleKey            = "sample_key"
-	lrSampleTypeKey        = "sample_type"
-	lrSampleEncodingKey    = "sample_encoding"
+	OTLPLogStreamsUIDsKey    = "com.neblic.streams"
+	OTLPLogSampleKey         = "com.neblic.sample.key"
+	OTLPLogSampleTypeKey     = "com.neblic.sample.type"
+	OTLPLogSampleEncodingKey = "com.neblic.sample.encoding"
 )
 
 type Encoding uint8
@@ -46,9 +44,9 @@ func ParseSampleEncoding(enc string) Encoding {
 type MetadataKey string
 
 const (
-	EventUID  MetadataKey = "event_uid"
-	EventRule MetadataKey = "event_rule"
-	DigestUID MetadataKey = "digest_uid"
+	EventUID  MetadataKey = "com.neblic.event.uid"
+	EventRule MetadataKey = "com.neblic.digest.rule"
+	DigestUID MetadataKey = "com.neblic.digest.uid"
 )
 
 // Sample defines a sample to be exported

--- a/sampler/test/sampler_behavior_test.go
+++ b/sampler/test/sampler_behavior_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neblic/platform/controlplane/control"
 	"github.com/neblic/platform/controlplane/protos"
 	"github.com/neblic/platform/controlplane/server/mock"
+	dataplaneSample "github.com/neblic/platform/dataplane/sample"
 	"github.com/neblic/platform/logging"
 	"github.com/neblic/platform/sampler"
 	otlpmock "github.com/neblic/platform/sampler/internal/sample/exporter/otlp/mock"
@@ -495,7 +496,7 @@ var _ = Describe("Sampler", func() {
 				require.Equal(GinkgoT(), scopeLogs.Len(), 1)
 				logRecords := scopeLogs.At(0).LogRecords()
 				require.Equal(GinkgoT(), logRecords.Len(), 1)
-				sampleTypeVal, ok := logRecords.At(0).Attributes().Get("sample_type")
+				sampleTypeVal, ok := logRecords.At(0).Attributes().Get(dataplaneSample.OTLPLogSampleTypeKey)
 				require.True(GinkgoT(), ok)
 				assert.Equal(GinkgoT(), sampleTypeVal.AsString(), "struct-digest")
 			})


### PR DESCRIPTION
## Describe your changes
After this refactor, the generated OTLP structures follow more tightly the OpenTelementry specification. The following changes have been made:
- Attributes follow the spcified convention defined in https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/#recommendations-for-application-developers
- Samplers are encoded in the context of scope instead of being an attribute set at the resource level. Sampler name is encoded using the scope name

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
