### PR TITLE
build(collector): set contrib packages to exisiting version

### DIFF
--- a/dist/otelcol/ocb.yaml
+++ b/dist/otelcol/ocb.yaml
@@ -12,9 +12,9 @@ replaces:
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.94.1
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.94.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.94.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.94.0
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.94.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.94.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.94.1
   - import: github.com/neblic/platform/controlplane/server/otelcolext
     gomod: github.com/neblic/platform v0.0.0
@@ -23,5 +23,5 @@ receivers:
 extensions:
   - import: github.com/neblic/platform/controlplane/server/otelcolext/bearerauthextension
     gomod: github.com/neblic/platform v0.0.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.94.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.94.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.94.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.94.0


### PR DESCRIPTION
## Describe your changes
` github.com/open-telemetry/opentelemetry-collector-contrib/*` packages were set o a version that does not exist

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made the appropriate changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If it is a major user facing functionality, I have added behavioural tests
- [x] If it is a critical part of the code or of significant complexity, I have added thorough testing
